### PR TITLE
Implement code block and inline code visitors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1852,6 +1852,7 @@ dependencies = [
  "eure-tree",
  "eure-value",
  "num-bigint",
+ "regex",
  "thiserror 2.0.17",
 ]
 

--- a/crates/eure/Cargo.toml
+++ b/crates/eure/Cargo.toml
@@ -15,4 +15,5 @@ eure-parol = { workspace = true }
 eure-tree = { workspace = true }
 eure-value = { workspace = true }
 num-bigint = { workspace = true }
+regex = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
- Add helper functions to parse language from code start tokens
- Implement visit_inline_code_1 for single backtick inline code
- Implement visit_inline_code_start_2/end_2 for double backtick inline code
- Implement visit_code_block_start/end_3/4/5/6 for code blocks (3-6 backticks)
- Update visit_terminal to collect terminals when inside code context
- Use TerminalTokens helper to construct code values
- Support language tags in both inline code and code blocks

All 8 code variants (InlineCode1, InlineCode2, CodeBlock3-6) are now implemented.