### PR TITLE
feat(schema): unify range syntax with $range string format

### DIFF
--- a/assets/eure-schema.schema.eure
+++ b/assets/eure-schema.schema.eure
@@ -269,56 +269,38 @@ variants {
   length-max = 2
 
   /// Integer type with optional range and multiple-of constraints.
+  /// Range syntax supports two formats:
+  /// - Rust-style: "0..100" (exclusive end), "0..=100" (inclusive end), "0..", "..100", "..=100"
+  /// - Interval notation: "[0, 100]", "[0, 100)", "(0, 100]", "(0, 100)", "[0, )", "(, 100]"
   @variants.integer
-  min = .integer
-  min.$optional = true
-  max = .integer
-  max.$optional = true
-  exclusive-min = .integer
-  exclusive-min.$optional = true
-  exclusive-max = .integer
-  exclusive-max.$optional = true
+  range = .string
+  range.$optional = true
   multiple-of = .integer
   multiple-of.$optional = true
 
   /// Shorthand: field.$type = .integer
-  /// Supports constraint extensions: $min, $max, $exclusive-min, $exclusive-max, $multiple-of
+  /// Supports constraint extensions: $range, $multiple-of
   @variants.integer-shorthand = { => .integer, $variant: literal }
-  @variants.integer-shorthand.$ext-type.min = .integer
-  @variants.integer-shorthand.$ext-type.min.$optional = true
-  @variants.integer-shorthand.$ext-type.max = .integer
-  @variants.integer-shorthand.$ext-type.max.$optional = true
-  @variants.integer-shorthand.$ext-type.exclusive-min = .integer
-  @variants.integer-shorthand.$ext-type.exclusive-min.$optional = true
-  @variants.integer-shorthand.$ext-type.exclusive-max = .integer
-  @variants.integer-shorthand.$ext-type.exclusive-max.$optional = true
+  @variants.integer-shorthand.$ext-type.range = .string
+  @variants.integer-shorthand.$ext-type.range.$optional = true
   @variants.integer-shorthand.$ext-type.multiple-of = .integer
   @variants.integer-shorthand.$ext-type.multiple-of.$optional = true
 
   /// Float type with optional range and multiple-of constraints.
+  /// Range syntax supports two formats:
+  /// - Rust-style: "0.0..100.0" (exclusive end), "0.0..=100.0" (inclusive end), "0.0..", "..100.0", "..=100.0"
+  /// - Interval notation: "[0.0, 100.0]", "[0.0, 100.0)", "(0.0, 100.0]", "(0.0, 100.0)", "[0.0, )", "(, 100.0]"
   @variants.float
-  min = .float
-  min.$optional = true
-  max = .float
-  max.$optional = true
-  exclusive-min = .float
-  exclusive-min.$optional = true
-  exclusive-max = .float
-  exclusive-max.$optional = true
+  range = .string
+  range.$optional = true
   multiple-of = .float
   multiple-of.$optional = true
 
   /// Shorthand: field.$type = .float
-  /// Supports constraint extensions: $min, $max, $exclusive-min, $exclusive-max, $multiple-of
+  /// Supports constraint extensions: $range, $multiple-of
   @variants.float-shorthand = { => .float, $variant: literal }
-  @variants.float-shorthand.$ext-type.min = .float
-  @variants.float-shorthand.$ext-type.min.$optional = true
-  @variants.float-shorthand.$ext-type.max = .float
-  @variants.float-shorthand.$ext-type.max.$optional = true
-  @variants.float-shorthand.$ext-type.exclusive-min = .float
-  @variants.float-shorthand.$ext-type.exclusive-min.$optional = true
-  @variants.float-shorthand.$ext-type.exclusive-max = .float
-  @variants.float-shorthand.$ext-type.exclusive-max.$optional = true
+  @variants.float-shorthand.$ext-type.range = .string
+  @variants.float-shorthand.$ext-type.range.$optional = true
   @variants.float-shorthand.$ext-type.multiple-of = .float
   @variants.float-shorthand.$ext-type.multiple-of.$optional = true
 

--- a/assets/eure-schema.schema.eure
+++ b/assets/eure-schema.schema.eure
@@ -165,6 +165,15 @@ $ext-type.types = {
   @variants.schema = .$types.type
 }
 
+/// Range string format for numeric constraints.
+/// Supports two formats:
+/// - Rust-style: "0..100", "0..=100", "0..", "..100", "..=100"
+/// - Interval notation: "[0, 100]", "[0, 100)", "(0, 100]", "(0, 100)", "[0, )", "(, 100]"
+@ $types.range-string {
+  $variant: string
+  pattern = "^((-?\\d+(\\.\\d+)?)?\\.\\.=?(-?\\d+(\\.\\d+)?)?|[\\[\\(](-?\\d+(\\.\\d+)?)?, *(-?\\d+(\\.\\d+)?)?[\\]\\)])$"
+}
+
 /// Which way to represent a document path in a document.
 @ $types.binding-style
 $variant: union
@@ -269,11 +278,8 @@ variants {
   length-max = 2
 
   /// Integer type with optional range and multiple-of constraints.
-  /// Range syntax supports two formats:
-  /// - Rust-style: "0..100" (exclusive end), "0..=100" (inclusive end), "0..", "..100", "..=100"
-  /// - Interval notation: "[0, 100]", "[0, 100)", "(0, 100]", "(0, 100)", "[0, )", "(, 100]"
   @variants.integer
-  range = .string
+  range = .$types.range-string
   range.$optional = true
   multiple-of = .integer
   multiple-of.$optional = true
@@ -281,17 +287,14 @@ variants {
   /// Shorthand: field.$type = .integer
   /// Supports constraint extensions: $range, $multiple-of
   @variants.integer-shorthand = { => .integer, $variant: literal }
-  @variants.integer-shorthand.$ext-type.range = .string
+  @variants.integer-shorthand.$ext-type.range = .$types.range-string
   @variants.integer-shorthand.$ext-type.range.$optional = true
   @variants.integer-shorthand.$ext-type.multiple-of = .integer
   @variants.integer-shorthand.$ext-type.multiple-of.$optional = true
 
   /// Float type with optional range and multiple-of constraints.
-  /// Range syntax supports two formats:
-  /// - Rust-style: "0.0..100.0" (exclusive end), "0.0..=100.0" (inclusive end), "0.0..", "..100.0", "..=100.0"
-  /// - Interval notation: "[0.0, 100.0]", "[0.0, 100.0)", "(0.0, 100.0]", "(0.0, 100.0)", "[0.0, )", "(, 100.0]"
   @variants.float
-  range = .string
+  range = .$types.range-string
   range.$optional = true
   multiple-of = .float
   multiple-of.$optional = true
@@ -299,7 +302,7 @@ variants {
   /// Shorthand: field.$type = .float
   /// Supports constraint extensions: $range, $multiple-of
   @variants.float-shorthand = { => .float, $variant: literal }
-  @variants.float-shorthand.$ext-type.range = .string
+  @variants.float-shorthand.$ext-type.range = .$types.range-string
   @variants.float-shorthand.$ext-type.range.$optional = true
   @variants.float-shorthand.$ext-type.multiple-of = .float
   @variants.float-shorthand.$ext-type.multiple-of.$optional = true

--- a/docs/schema-extensions.md
+++ b/docs/schema-extensions.md
@@ -129,17 +129,18 @@ username.$pattern = "^[a-z0-9_]+$"
 ```eure
 @ age {
   $variant: integer
-  min = 0
-  max = 150
+  range = "[0, 150]"
 }
 
-// Or with exclusive bounds
-@ temperature {
+// Rust-style range syntax
+@ index {
   $variant: integer
-  exclusive-min = -273
-  exclusive-max = 1000
-  multiple-of = 1
+  range = "0..100"      // 0 <= x < 100
 }
+
+// Or using shorthand with extensions
+age = .integer
+age.$range = "0..=150"  // 0 <= x <= 150
 ```
 
 ### Float Type with Constraints
@@ -147,10 +148,32 @@ username.$pattern = "^[a-z0-9_]+$"
 ```eure
 @ probability {
   $variant: float
-  min = 0.0
-  max = 1.0
+  range = "[0.0, 1.0)"  // 0 <= x < 1
 }
+
+// Rust-style
+temperature = .float
+temperature.$range = "-273.15.."  // x >= -273.15
 ```
+
+### Range Syntax
+
+Two formats are supported:
+
+**Rust-style** (left side always inclusive):
+- `"0..100"` → 0 ≤ x < 100
+- `"0..=100"` → 0 ≤ x ≤ 100
+- `"0.."` → x ≥ 0
+- `"..100"` → x < 100
+- `"..=100"` → x ≤ 100
+
+**Interval notation** (supports all 4 combinations):
+- `"[0, 100]"` → 0 ≤ x ≤ 100 (both inclusive)
+- `"[0, 100)"` → 0 ≤ x < 100 (left inclusive, right exclusive)
+- `"(0, 100]"` → 0 < x ≤ 100 (left exclusive, right inclusive)
+- `"(0, 100)"` → 0 < x < 100 (both exclusive)
+- `"[0, )"` → x ≥ 0
+- `"(, 100]"` → x ≤ 100
 
 ### Code Type
 


### PR DESCRIPTION
Replace separate min/max/exclusive-min/exclusive-max fields with a single
$range field that accepts two intuitive string formats:

- Rust-style: "0..100", "0..=100", "0..", "..100", "..=100"
- Interval notation: "[0, 100]", "[0, 100)", "(0, 100]", "(0, 100)"

This prevents the ambiguous case where both inclusive and exclusive bounds
could be specified for the same endpoint.