### PR TITLE
feat(schema): add cross-schema type references ($import/$export)

### DIFF
--- a/assets/eure-schema.schema.eure
+++ b/assets/eure-schema.schema.eure
@@ -111,6 +111,23 @@
 ///    - $deprecated: marks as deprecated
 ///    - $default: default value
 ///    - $examples: example values in Eure code
+///
+/// 7. Cross-Schema Type References:
+///    Schemas can import types from other schemas using $import.
+///
+///    $import = { common => "common.schema.eure" }
+///
+///    Then reference imported types using: .$types.<namespace>.<type-name>
+///    - .$types.common.username    (imported from common.schema.eure)
+///    - .$types.local-type         (local type, no namespace)
+///
+///    Resolution rules:
+///    - Path length 2 (.$types.T): Local type reference
+///    - Path length 3 (.$types.N.T): External type reference (N must be in $import)
+///
+///    Schemas can optionally declare which types to export using $export.
+///    - $export = "*"              (export all types, default)
+///    - $export = ["username"]     (export only listed types)
 
 $schema = "eure-schema.schema.eure"
 
@@ -128,6 +145,39 @@ $ext-type.types = {
   key => .string
   value => .$types.type
 }
+
+/// Allows schemas to import types from other schemas.
+/// Users can define imports like: $import = { common => "common.schema.eure" }
+/// and reference imported types as: .$types.common.username
+///
+/// The namespace (e.g., "common") is used as a prefix when referencing types.
+/// The path (e.g., "common.schema.eure") is resolved relative to the current schema file.
+///
+/// Note: Imports are resolved at schema bundling/validation time, not at runtime.
+/// Distributed schemas should be self-contained (all imports inlined).
+$ext-type.import = {
+  $variant: map
+  key => .string    // namespace name
+  value => .string  // schema file path (relative or absolute)
+}
+$ext-type.import.$optional = true
+
+/// Allows schemas to declare which types are exported (public).
+/// - $export = "*" exports all types (default behavior if $export is omitted)
+/// - $export = ["type1", "type2"] exports only the listed types
+///
+/// Types not in the export list cannot be referenced from other schemas.
+@ $types.export-policy {
+  $variant: union
+
+  /// Export all types defined in this schema.
+  @variants.all = { => "*", $variant: literal }
+
+  /// Export only the explicitly listed types.
+  @variants.explicit = [.string]
+}
+$ext-type.export = .$types.export-policy
+$ext-type.export.$optional = true  // Default: export all ("*")
 
 /// How variants should be represented in the data model.
 @ $types.variant-repr {
@@ -433,11 +483,25 @@ variants {
   variants.15 = (.$types.type, .$types.type, .$types.type, .$types.type, .$types.type, .$types.type, .$types.type, .$types.type, .$types.type, .$types.type, .$types.type, .$types.type, .$types.type, .$types.type, .$types.type)
   variants.16 = (.$types.type, .$types.type, .$types.type, .$types.type, .$types.type, .$types.type, .$types.type, .$types.type, .$types.type, .$types.type, .$types.type, .$types.type, .$types.type, .$types.type, .$types.type, .$types.type)
 
-  // Type reference using path syntax (e.g., .$types.my-type).
-  // This is used to reference other type definitions within the schema.
+  /// Type reference using path syntax.
+  /// Supports both local and cross-schema type references:
+  ///
+  /// Local reference (path length 2):
+  ///   .$types.my-type
+  ///   References a type defined in the current schema via $types.my-type
+  ///
+  /// Cross-schema reference (path length 3):
+  ///   .$types.common.username
+  ///   References type "username" from schema imported as "common" via $import
+  ///
+  /// Resolution:
+  /// - Local refs are resolved against $types in the current schema
+  /// - External refs require matching $import entry and exported type
   @variants.ref
   $variant: path
   starts-with = .$types
+  length-min = 2
+  length-max = 3
 
   // Path schema type with optional constraints like starts-with, min-length, max-length, etc.
   // This is the actual data type for storing path values, not a type reference.


### PR DESCRIPTION
Add support for importing and referencing types from other schemas:
- $import: declare schema dependencies with namespace aliases
- $export: optionally declare which types are public
- .$types.<namespace>.<type-name> syntax for external references

Resolution rules:
- Path length 2 (.$types.T): local type reference
- Path length 3 (.$types.N.T): external reference via $import

Imports are resolved at bundling time, maintaining EURE's
self-contained document principle.