### PR TITLE
refactor(schema): remove constraint extensions from type shorthands

### DIFF
--- a/assets/eure-schema.schema.eure
+++ b/assets/eure-schema.schema.eure
@@ -245,14 +245,8 @@ variants {
   pattern.$optional = true
 
   /// Shorthand: field.$type = .string
-  /// Supports constraint extensions: $min-length, $max-length, $pattern
+  /// For constraints, use the full form with $variant: string
   @variants.string-shorthand = { => .string, $variant: literal }
-  @variants.string-shorthand.$ext-type.min-length = .integer
-  @variants.string-shorthand.$ext-type.min-length.$optional = true
-  @variants.string-shorthand.$ext-type.max-length = .integer
-  @variants.string-shorthand.$ext-type.max-length.$optional = true
-  @variants.string-shorthand.$ext-type.pattern = .string
-  @variants.string-shorthand.$ext-type.pattern.$optional = true
 
   /// Code type for code blocks or inline code.
   /// Can be used standalone (treated as plaintext) or with a language specifier.
@@ -282,18 +276,8 @@ variants {
   multiple-of.$optional = true
 
   /// Shorthand: field.$type = .integer
-  /// Supports constraint extensions: $min, $max, $exclusive-min, $exclusive-max, $multiple-of
+  /// For constraints, use the full form with $variant: integer
   @variants.integer-shorthand = { => .integer, $variant: literal }
-  @variants.integer-shorthand.$ext-type.min = .integer
-  @variants.integer-shorthand.$ext-type.min.$optional = true
-  @variants.integer-shorthand.$ext-type.max = .integer
-  @variants.integer-shorthand.$ext-type.max.$optional = true
-  @variants.integer-shorthand.$ext-type.exclusive-min = .integer
-  @variants.integer-shorthand.$ext-type.exclusive-min.$optional = true
-  @variants.integer-shorthand.$ext-type.exclusive-max = .integer
-  @variants.integer-shorthand.$ext-type.exclusive-max.$optional = true
-  @variants.integer-shorthand.$ext-type.multiple-of = .integer
-  @variants.integer-shorthand.$ext-type.multiple-of.$optional = true
 
   /// Float type with optional range and multiple-of constraints.
   @variants.float
@@ -309,18 +293,8 @@ variants {
   multiple-of.$optional = true
 
   /// Shorthand: field.$type = .float
-  /// Supports constraint extensions: $min, $max, $exclusive-min, $exclusive-max, $multiple-of
+  /// For constraints, use the full form with $variant: float
   @variants.float-shorthand = { => .float, $variant: literal }
-  @variants.float-shorthand.$ext-type.min = .float
-  @variants.float-shorthand.$ext-type.min.$optional = true
-  @variants.float-shorthand.$ext-type.max = .float
-  @variants.float-shorthand.$ext-type.max.$optional = true
-  @variants.float-shorthand.$ext-type.exclusive-min = .float
-  @variants.float-shorthand.$ext-type.exclusive-min.$optional = true
-  @variants.float-shorthand.$ext-type.exclusive-max = .float
-  @variants.float-shorthand.$ext-type.exclusive-max.$optional = true
-  @variants.float-shorthand.$ext-type.multiple-of = .float
-  @variants.float-shorthand.$ext-type.multiple-of.$optional = true
 
   /// Boolean type (true/false).
   /// Usage: field.$type = .boolean
@@ -375,20 +349,12 @@ variants {
   $ext-type.binding-style.$optional = true
 
   // Shorthand: field.$type = [.integer]
-  // Supports constraint extensions: $min-length, $max-length, $unique, $contains
+  // For constraints, use the full form with $variant: array
   @variants.array-shorthand
   $variant: array
   item = .$types.type
   min-length = 1
   max-length = 1
-  $ext-type.min-length = .integer
-  $ext-type.min-length.$optional = true
-  $ext-type.max-length = .integer
-  $ext-type.max-length.$optional = true
-  $ext-type.unique = .boolean
-  $ext-type.unique.$optional = true
-  $ext-type.contains = .$types.type
-  $ext-type.contains.$optional = true
 
   /// Map type with dynamic keys (all keys have the same type, all values have the same type).
   /// Unlike record, keys are not fixed - any key matching the key type is allowed.
@@ -450,12 +416,6 @@ variants {
   max-length.$optional = true
 
   /// Shorthand: field.$type = .path
-  /// Supports constraint extensions: $starts-with, $min-length, $max-length
+  /// For constraints, use the full form with $variant: path
   @variants.path-shorthand = { => .path, $variant: literal }
-  @variants.path-shorthand.$ext-type.starts-with = .path
-  @variants.path-shorthand.$ext-type.starts-with.$optional = true
-  @variants.path-shorthand.$ext-type.min-length = .integer
-  @variants.path-shorthand.$ext-type.min-length.$optional = true
-  @variants.path-shorthand.$ext-type.max-length = .integer
-  @variants.path-shorthand.$ext-type.max-length.$optional = true
 }

--- a/crates/eure-editor-support/tests/schema_validation_test.rs
+++ b/crates/eure-editor-support/tests/schema_validation_test.rs
@@ -34,10 +34,13 @@ fn test_self_describing_validation() {
     let input = r#"
 # Pure schema document (no data mixed in)
 @ $types.Person {
-    name.$type = .string
-    name.$length = (1, 50)
-    
-    age.$type = .number
+    @ name {
+        $variant: string
+        min-length = 1
+        max-length = 50
+    }
+
+    age = .float
     age.$optional = true
 }
 "#;

--- a/docs/schema-extensions.md
+++ b/docs/schema-extensions.md
@@ -106,22 +106,18 @@ metadata = .any
 
 **Shorthands:** `.string`, `.integer`, `.float`, `.boolean`, `.null`, `.any`
 
+Shorthands are for simple types without constraints. For constraints, use the full form.
+
 ### String Type with Constraints
 
 ```eure
-// Full form
+// Full form (required for constraints)
 @ username {
   $variant: string
   min-length = 3
   max-length = 20
   pattern = "^[a-z0-9_]+$"
 }
-
-// Or using shorthand with extensions
-username = .string
-username.$min-length = 3
-username.$max-length = 20
-username.$pattern = "^[a-z0-9_]+$"
 ```
 
 ### Integer Type with Constraints
@@ -533,9 +529,12 @@ $schema = "eure-schema.schema.eure"
   age.$optional = true
   age.$description: User's age in years.
 
-  tags = [.string]
+  @ tags {
+    $variant: array
+    item = .string
+    unique = true
+  }
   tags.$optional = true
-  tags.$unique = true
 }
 
 // Set root type


### PR DESCRIPTION
Simplify the type system by removing $ext-type constraint definitions
from shorthand type variants. Now:

- Shorthands (.string, .integer, .float, etc.) are for simple types
  without constraints
- For types with constraints, use the full form with $variant

This avoids ugly paths like `a.$type.$min` when using inline type
annotations with constraints in data documents.

Changes:
- Remove $ext-type.min, $ext-type.max, etc. from shorthand variants
  in meta-schema
- Update documentation to reflect the new convention
- Update tests to use full form for constrained types