### PR TITLE
Remove inappropriate use of unsafe from Identifier::new_unchecked

### DIFF
--- a/crates/eure-schema/src/identifiers.rs
+++ b/crates/eure-schema/src/identifiers.rs
@@ -1,20 +1,14 @@
 use eure_value::identifier::Identifier;
 
-// SAFETY: All these strings are valid identifiers according to Eure rules:
-// - Start with XID_Start character or underscore
-// - Contain only XID_Continue characters or hyphens
-// - Are not reserved keywords (true, false, null)
-// - Do not start with $
-
-pub const SCHEMA: Identifier = unsafe { Identifier::new_unchecked("schema") };
-pub const CASCADE_TYPE: Identifier = unsafe { Identifier::new_unchecked("cascade-type") };
-pub const RENAME: Identifier = unsafe { Identifier::new_unchecked("rename") };
-pub const RENAME_ALL: Identifier = unsafe { Identifier::new_unchecked("rename-all") };
-pub const VARIANTS: Identifier = unsafe { Identifier::new_unchecked("variants") };
-pub const VARIANT_REPR: Identifier = unsafe { Identifier::new_unchecked("variant-repr") };
-pub const VARIANT: Identifier = unsafe { Identifier::new_unchecked("variant") };
-pub const ARRAY: Identifier = unsafe { Identifier::new_unchecked("array") };
-pub const UNKNOWN: Identifier = unsafe { Identifier::new_unchecked("unknown") };
-pub const UNKNOWN_CAPS: Identifier = unsafe { Identifier::new_unchecked("Unknown") };
-pub const TAG: Identifier = unsafe { Identifier::new_unchecked("tag") };
-pub const CONTENT: Identifier = unsafe { Identifier::new_unchecked("content") };
+pub const SCHEMA: Identifier = Identifier::new_unchecked("schema");
+pub const CASCADE_TYPE: Identifier = Identifier::new_unchecked("cascade-type");
+pub const RENAME: Identifier = Identifier::new_unchecked("rename");
+pub const RENAME_ALL: Identifier = Identifier::new_unchecked("rename-all");
+pub const VARIANTS: Identifier = Identifier::new_unchecked("variants");
+pub const VARIANT_REPR: Identifier = Identifier::new_unchecked("variant-repr");
+pub const VARIANT: Identifier = Identifier::new_unchecked("variant");
+pub const ARRAY: Identifier = Identifier::new_unchecked("array");
+pub const UNKNOWN: Identifier = Identifier::new_unchecked("unknown");
+pub const UNKNOWN_CAPS: Identifier = Identifier::new_unchecked("Unknown");
+pub const TAG: Identifier = Identifier::new_unchecked("tag");
+pub const CONTENT: Identifier = Identifier::new_unchecked("content");

--- a/crates/eure-value/src/identifier.rs
+++ b/crates/eure-value/src/identifier.rs
@@ -84,12 +84,16 @@ pub enum IdentifierError {
 impl Identifier {
     /// Creates a new Identifier without validation.
     ///
-    /// # Safety
-    /// The caller must ensure that the string is a valid identifier according to Eure rules:
+    /// This function is intended for creating compile-time constants where the
+    /// identifier string is known to be valid. The caller should ensure that the
+    /// string is a valid identifier according to Eure rules:
     /// - Must start with XID_Start character or underscore
     /// - Can contain XID_Continue characters or hyphens
     /// - Must not start with $
-    pub const unsafe fn new_unchecked(s: &'static str) -> Self {
+    ///
+    /// Note: This function is not marked `unsafe` because passing an invalid string
+    /// does not cause memory unsafety - it only results in a logically invalid Identifier.
+    pub const fn new_unchecked(s: &'static str) -> Self {
         Identifier(Cow::Borrowed(s))
     }
 
@@ -196,11 +200,11 @@ mod tests {
     #[test]
     fn test_identifier_new_unchecked() {
         // This test verifies that const construction works
-        const TEST_ID: Identifier = unsafe { Identifier::new_unchecked("test-const") };
+        const TEST_ID: Identifier = Identifier::new_unchecked("test-const");
         assert_eq!(TEST_ID.as_ref(), "test-const");
 
         // Verify it's using borrowed variant
-        let id = unsafe { Identifier::new_unchecked("borrowed") };
+        let id = Identifier::new_unchecked("borrowed");
         assert_eq!(id.as_ref(), "borrowed");
     }
 }


### PR DESCRIPTION
The `unsafe` keyword was being used incorrectly here - `new_unchecked`
only wraps a string in `Cow::Borrowed`, which cannot cause memory
unsafety. Passing an invalid identifier string is a logic error, not
a memory safety violation.

Rust's `unsafe` should only be used for operations that could cause
undefined behavior, not for unvalidated constructors.