### PR TITLE
feat(eure-value): add $variant extension support to UnionParser

### DIFF
--- a/crates/eure-value/src/parse.rs
+++ b/crates/eure-value/src/parse.rs
@@ -62,7 +62,7 @@ pub struct ParseError {
 }
 
 /// Error type for parsing failures.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, PartialEq, thiserror::Error)]
 pub enum ParseErrorKind {
     /// Unexpected uninitialized value.
     #[error("unexpected uninitialized value")]

--- a/crates/eure-value/src/parse/union.rs
+++ b/crates/eure-value/src/parse/union.rs
@@ -4,13 +4,16 @@
 
 extern crate alloc;
 
-use alloc::boxed::Box;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
 use crate::document::{EureDocument, NodeId};
+use crate::identifier::Identifier;
 
 use super::{DocumentParser, ParseError, ParseErrorKind};
+
+/// The `$variant` extension identifier.
+pub const VARIANT: Identifier = Identifier::new_unchecked("variant");
 
 /// Helper for parsing union types from Eure documents.
 ///
@@ -18,6 +21,7 @@ use super::{DocumentParser, ParseError, ParseErrorKind};
 /// - Exactly one variant must match
 /// - Multiple matches resolved by registration order (priority)
 /// - Short-circuits on first priority variant match
+/// - When `$variant` extension is specified, matches by name directly
 ///
 /// # Example
 ///
@@ -40,43 +44,42 @@ use super::{DocumentParser, ParseError, ParseErrorKind};
 pub struct UnionParser<'doc, T> {
     doc: &'doc EureDocument,
     node_id: NodeId,
-    /// Priority variants - tried in order, first match wins (short-circuit)
-    priority_variants: Vec<(String, Box<dyn ErasedParser<'doc, T> + 'doc>)>,
-    /// Non-priority variants - always tried for ambiguity detection
-    other_variants: Vec<(String, Box<dyn ErasedParser<'doc, T> + 'doc>)>,
-}
-
-/// Type-erased parser trait for storing heterogeneous parsers.
-trait ErasedParser<'doc, T> {
-    fn parse_erased(
-        self: Box<Self>,
-        doc: &'doc EureDocument,
-        node_id: NodeId,
-    ) -> Result<T, ParseError>;
-}
-
-impl<'doc, T, P> ErasedParser<'doc, T> for P
-where
-    P: DocumentParser<'doc, Output = T>,
-{
-    fn parse_erased(
-        self: Box<Self>,
-        doc: &'doc EureDocument,
-        node_id: NodeId,
-    ) -> Result<T, ParseError> {
-        (*self).parse(doc, node_id)
-    }
+    /// Variant name from `$variant` extension (if specified)
+    variant_name: Option<String>,
+    /// Result when `$variant` is specified and matches
+    variant_result: Option<Result<T, ParseError>>,
+    /// All registered variant names (for UnknownVariant check)
+    all_variant_names: Vec<String>,
+    /// First matching priority variant (short-circuit result)
+    priority_result: Option<T>,
+    /// Matching non-priority variants
+    other_results: Vec<(String, T)>,
+    /// Failed non-priority variants (for error reporting)
+    other_failures: Vec<(String, ParseError)>,
 }
 
 impl<'doc, T> UnionParser<'doc, T> {
     /// Create a new UnionParser for the given node.
     pub(crate) fn new(doc: &'doc EureDocument, node_id: NodeId) -> Self {
+        let variant_name = Self::extract_variant(doc, node_id);
+
         Self {
             doc,
             node_id,
-            priority_variants: Vec::new(),
-            other_variants: Vec::new(),
+            variant_name,
+            variant_result: None,
+            all_variant_names: Vec::new(),
+            priority_result: None,
+            other_results: Vec::new(),
+            other_failures: Vec::new(),
         }
+    }
+
+    /// Extract the `$variant` extension value from the node.
+    fn extract_variant(doc: &EureDocument, node_id: NodeId) -> Option<String> {
+        let node = doc.node(node_id);
+        let variant_node_id = node.extensions.get(&VARIANT)?;
+        doc.parse::<&str>(*variant_node_id).ok().map(String::from)
     }
 
     /// Register a priority variant.
@@ -87,8 +90,19 @@ impl<'doc, T> UnionParser<'doc, T> {
     where
         P: DocumentParser<'doc, Output = T> + 'doc,
     {
-        self.priority_variants
-            .push((name.to_string(), Box::new(parser)));
+        self.all_variant_names.push(name.to_string());
+
+        if let Some(ref vn) = self.variant_name {
+            // $variant specified: only parse if name matches and no result yet
+            if vn == name && self.variant_result.is_none() {
+                self.variant_result = Some(parser.parse(self.doc, self.node_id));
+            }
+        } else if self.priority_result.is_none()
+            && let Ok(value) = parser.parse(self.doc, self.node_id)
+        {
+            // No $variant: short-circuit on first match
+            self.priority_result = Some(value);
+        }
         self
     }
 
@@ -100,8 +114,22 @@ impl<'doc, T> UnionParser<'doc, T> {
     where
         P: DocumentParser<'doc, Output = T> + 'doc,
     {
-        self.other_variants
-            .push((name.to_string(), Box::new(parser)));
+        self.all_variant_names.push(name.to_string());
+
+        if let Some(ref vn) = self.variant_name {
+            // $variant specified: only parse if name matches and no result yet
+            if vn == name && self.variant_result.is_none() {
+                self.variant_result = Some(parser.parse(self.doc, self.node_id));
+            }
+        } else {
+            // No $variant: try all for ambiguity detection (only if no priority match)
+            if self.priority_result.is_none() {
+                match parser.parse(self.doc, self.node_id) {
+                    Ok(value) => self.other_results.push((name.to_string(), value)),
+                    Err(e) => self.other_failures.push((name.to_string(), e)),
+                }
+            }
+        }
         self
     }
 
@@ -109,39 +137,41 @@ impl<'doc, T> UnionParser<'doc, T> {
     ///
     /// Returns:
     /// - `Ok(T)` if exactly one variant matches (or priority resolves ambiguity)
+    /// - `Err(UnknownVariant)` if `$variant` specifies an unregistered name
     /// - `Err(NoMatchingVariant)` if no variants match
     /// - `Err(AmbiguousUnion)` if multiple non-priority variants match
     pub fn parse(self) -> Result<T, ParseError> {
-        let doc = self.doc;
         let node_id = self.node_id;
 
-        // 1. Try priority variants in order (short-circuit on first match)
-        for (_name, parser) in self.priority_variants {
-            match parser.parse_erased(doc, node_id) {
-                Ok(value) => return Ok(value),
-                Err(_) => continue,
+        // $variant specified
+        if let Some(variant_name) = self.variant_name {
+            // Check if variant name is registered
+            if !self.all_variant_names.iter().any(|n| n == &variant_name) {
+                return Err(ParseError {
+                    node_id,
+                    kind: ParseErrorKind::UnknownVariant(variant_name),
+                });
             }
+            // Return the parse result (success or failure)
+            return self.variant_result.unwrap();
         }
 
-        // 2. Try all non-priority variants
-        let mut matching: Vec<(String, T)> = Vec::new();
-        let mut failures: Vec<(String, ParseError)> = Vec::new();
-
-        for (name, parser) in self.other_variants {
-            match parser.parse_erased(doc, node_id) {
-                Ok(value) => matching.push((name, value)),
-                Err(e) => failures.push((name, e)),
-            }
+        // No $variant: use priority/other logic
+        if let Some(value) = self.priority_result {
+            return Ok(value);
         }
 
-        // 3. Determine result
-        match matching.len() {
-            0 => Err(Self::no_match_error(node_id, failures)),
-            1 => Ok(matching.into_iter().next().unwrap().1),
+        // Check non-priority variants
+        match self.other_results.len() {
+            0 => Err(Self::no_match_error(node_id, self.other_failures)),
+            1 => Ok(self.other_results.into_iter().next().unwrap().1),
             _ => Err(ParseError {
                 node_id,
                 kind: ParseErrorKind::AmbiguousUnion(
-                    matching.into_iter().map(|(name, _)| name).collect(),
+                    self.other_results
+                        .into_iter()
+                        .map(|(name, _)| name)
+                        .collect(),
                 ),
             }),
         }
@@ -185,6 +215,10 @@ mod tests {
     use crate::text::Text;
     use crate::value::PrimitiveValue;
 
+    fn identifier(s: &str) -> Identifier {
+        s.parse().unwrap()
+    }
+
     #[derive(Debug, PartialEq)]
     enum TestEnum {
         Foo,
@@ -196,6 +230,26 @@ mod tests {
         let root_id = doc.get_root_id();
         doc.node_mut(root_id).content =
             NodeValue::Primitive(PrimitiveValue::Text(Text::plaintext(text.to_string())));
+        doc
+    }
+
+    /// Create a document with $variant extension
+    fn create_doc_with_variant(content: &str, variant: &str) -> EureDocument {
+        let mut doc = EureDocument::new();
+        let root_id = doc.get_root_id();
+
+        // Set content
+        doc.node_mut(root_id).content =
+            NodeValue::Primitive(PrimitiveValue::Text(Text::plaintext(content.to_string())));
+
+        // Add $variant extension
+        let variant_node_id = doc
+            .add_extension(identifier("variant"), root_id)
+            .unwrap()
+            .node_id;
+        doc.node_mut(variant_node_id).content =
+            NodeValue::Primitive(PrimitiveValue::Text(Text::plaintext(variant.to_string())));
+
         doc
     }
 
@@ -308,5 +362,124 @@ mod tests {
             .unwrap();
 
         assert_eq!(result, "world");
+    }
+
+    // --- $variant extension tests ---
+
+    #[test]
+    fn test_variant_extension_match_success() {
+        // $variant = "bar" specified, "bar" parser succeeds
+        let doc = create_doc_with_variant("bar", "bar");
+        let root_id = doc.get_root_id();
+
+        let result: TestEnum = doc
+            .parse_union(root_id)
+            .variant("foo", |doc: &EureDocument, id| {
+                let s: &str = doc.parse(id)?;
+                if s == "foo" {
+                    Ok(TestEnum::Foo)
+                } else {
+                    Err(ParseError {
+                        node_id: id,
+                        kind: ParseErrorKind::UnknownVariant(s.to_string()),
+                    })
+                }
+            })
+            .variant("bar", |doc: &EureDocument, id| {
+                let s: &str = doc.parse(id)?;
+                if s == "bar" {
+                    Ok(TestEnum::Bar)
+                } else {
+                    Err(ParseError {
+                        node_id: id,
+                        kind: ParseErrorKind::UnknownVariant(s.to_string()),
+                    })
+                }
+            })
+            .parse()
+            .unwrap();
+
+        assert_eq!(result, TestEnum::Bar);
+    }
+
+    #[test]
+    fn test_variant_extension_unknown() {
+        // $variant = "unknown" specified, but "unknown" is not registered
+        let doc = create_doc_with_variant("hello", "unknown");
+        let root_id = doc.get_root_id();
+
+        let err = doc
+            .parse_union::<TestEnum>(root_id)
+            .variant("foo", |doc: &EureDocument, id| {
+                let s: &str = doc.parse(id)?;
+                if s == "foo" {
+                    Ok(TestEnum::Foo)
+                } else {
+                    Err(ParseError {
+                        node_id: id,
+                        kind: ParseErrorKind::UnknownVariant(s.to_string()),
+                    })
+                }
+            })
+            .variant("bar", |doc: &EureDocument, id| {
+                let s: &str = doc.parse(id)?;
+                if s == "bar" {
+                    Ok(TestEnum::Bar)
+                } else {
+                    Err(ParseError {
+                        node_id: id,
+                        kind: ParseErrorKind::UnknownVariant(s.to_string()),
+                    })
+                }
+            })
+            .parse()
+            .unwrap_err();
+
+        assert_eq!(err.node_id, root_id);
+        assert_eq!(
+            err.kind,
+            ParseErrorKind::UnknownVariant("unknown".to_string())
+        );
+    }
+
+    #[test]
+    fn test_variant_extension_match_parse_failure() {
+        // $variant = "bar" specified, "bar" parser fails (content is "wrong")
+        let doc = create_doc_with_variant("wrong", "bar");
+        let root_id = doc.get_root_id();
+
+        let err = doc
+            .parse_union::<TestEnum>(root_id)
+            .variant("foo", |doc: &EureDocument, id| {
+                let s: &str = doc.parse(id)?;
+                if s == "foo" {
+                    Ok(TestEnum::Foo)
+                } else {
+                    Err(ParseError {
+                        node_id: id,
+                        kind: ParseErrorKind::UnknownVariant(s.to_string()),
+                    })
+                }
+            })
+            .variant("bar", |doc: &EureDocument, id| {
+                let s: &str = doc.parse(id)?;
+                if s == "bar" {
+                    Ok(TestEnum::Bar)
+                } else {
+                    Err(ParseError {
+                        node_id: id,
+                        kind: ParseErrorKind::UnknownVariant(s.to_string()),
+                    })
+                }
+            })
+            .parse()
+            .unwrap_err();
+
+        // Parser's error is returned directly (not UnknownVariant for "bar")
+        assert_eq!(err.node_id, root_id);
+        assert_eq!(
+            err.kind,
+            ParseErrorKind::UnknownVariant("wrong".to_string())
+        );
     }
 }


### PR DESCRIPTION
- Refactor UnionParser to use incremental parsing
- Remove ErasedParser trait and Box allocation
- Add VARIANT constant for extension identifier
- Support $variant extension for explicit variant matching
- Return UnknownVariant error when $variant name is not registered
- Add PartialEq to ParseErrorKind for testing