### PR TITLE
feat(eure-tree): add get_shrunk_span function to exclude trivia from spans

### DIFF
--- a/crates/eure-tree/src/lib.rs
+++ b/crates/eure-tree/src/lib.rs
@@ -24,7 +24,7 @@ pub mod prelude {
     pub use crate::nodes::*;
     pub use crate::tree::{
         CharInfo, CstFacade, CstNodeId, DynamicTokenId, LineNumbers, NonTerminalData,
-        NonTerminalHandle as _, TerminalData, TerminalHandle as _,
+        NonTerminalHandle as _, TerminalData, TerminalHandle as _, get_shrunk_span,
     };
     pub use crate::visitor::{CstVisitor, CstVisitorSuper as _};
     pub use crate::{Cst, CstConstructError, CstNode, NodeKind};

--- a/crates/eure-tree/src/lib.rs
+++ b/crates/eure-tree/src/lib.rs
@@ -24,7 +24,7 @@ pub mod prelude {
     pub use crate::nodes::*;
     pub use crate::tree::{
         CharInfo, CstFacade, CstNodeId, DynamicTokenId, LineNumbers, NonTerminalData,
-        NonTerminalHandle as _, TerminalData, TerminalHandle as _, get_shrunk_span,
+        NonTerminalHandle as _, TerminalData, TerminalHandle as _,
     };
     pub use crate::visitor::{CstVisitor, CstVisitorSuper as _};
     pub use crate::{Cst, CstConstructError, CstNode, NodeKind};

--- a/crates/eure-tree/src/tree.rs
+++ b/crates/eure-tree/src/tree.rs
@@ -191,7 +191,7 @@ where
             .is_none_or(|children| children.is_empty())
     }
 
-    pub fn children(&self, node: CstNodeId) -> impl Iterator<Item = CstNodeId> + '_ {
+    pub fn children(&self, node: CstNodeId) -> impl DoubleEndedIterator<Item = CstNodeId> + '_ {
         self.children
             .get(&node)
             .into_iter()
@@ -491,7 +491,7 @@ pub trait CstFacade: Sized {
 
     fn has_no_children(&self, node: CstNodeId) -> bool;
 
-    fn children(&self, node: CstNodeId) -> impl Iterator<Item = CstNodeId>;
+    fn children(&self, node: CstNodeId) -> impl DoubleEndedIterator<Item = CstNodeId>;
 
     fn get_terminal(
         &self,
@@ -533,6 +533,94 @@ pub trait CstFacade: Sized {
             TerminalData::Dynamic(id) => Ok(self.dynamic_token(id).ok_or(id)),
         }
     }
+
+    /// Returns a span that excludes leading and trailing trivia (whitespace, newlines, comments).
+    ///
+    /// For terminal nodes:
+    /// - Always returns the input span (even for trivia terminals like whitespace/comments)
+    /// - Returns None only for dynamic terminals
+    ///
+    /// For non-terminal nodes:
+    /// - Recursively finds the first and last non-trivia descendant spans
+    /// - Returns the merged span of those two endpoints
+    /// - Falls back to the original span if all descendants are trivia
+    ///
+    /// This is useful when you want to get the "meaningful" span of a syntax node,
+    /// excluding any surrounding whitespace or comments.
+    fn get_shrunk_span(&self, node_id: CstNodeId) -> Option<InputSpan> {
+        match self.node_data(node_id)? {
+            CstNodeData::Terminal { data, .. } => {
+                // Always return the span for terminals (including trivia)
+                match data {
+                    TerminalData::Input(span) => Some(span),
+                    TerminalData::Dynamic(_) => None,
+                }
+            }
+            CstNodeData::NonTerminal { data, .. } => {
+                // Find first non-trivia span
+                let first_span = self
+                    .children(node_id)
+                    .find_map(|child| self.find_first_non_trivia_span(child));
+
+                // Find last non-trivia span
+                let last_span = self
+                    .children(node_id)
+                    .rev()
+                    .find_map(|child| self.find_last_non_trivia_span(child));
+
+                match (first_span, last_span) {
+                    (Some(first), Some(last)) => Some(first.merge(last)),
+                    (Some(span), None) | (None, Some(span)) => Some(span),
+                    (None, None) => {
+                        // All children are trivia or no children - fall back to original span
+                        match data {
+                            NonTerminalData::Input(span) if span != InputSpan::EMPTY => Some(span),
+                            _ => None,
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Helper: finds the first non-trivia span by depth-first search from the start.
+    fn find_first_non_trivia_span(&self, node_id: CstNodeId) -> Option<InputSpan> {
+        match self.node_data(node_id)? {
+            CstNodeData::Terminal { kind, data } => {
+                if kind.is_builtin_terminal() {
+                    None
+                } else {
+                    match data {
+                        TerminalData::Input(span) => Some(span),
+                        TerminalData::Dynamic(_) => None,
+                    }
+                }
+            }
+            CstNodeData::NonTerminal { .. } => self
+                .children(node_id)
+                .find_map(|child| self.find_first_non_trivia_span(child)),
+        }
+    }
+
+    /// Helper: finds the last non-trivia span by depth-first search from the end.
+    fn find_last_non_trivia_span(&self, node_id: CstNodeId) -> Option<InputSpan> {
+        match self.node_data(node_id)? {
+            CstNodeData::Terminal { kind, data } => {
+                if kind.is_builtin_terminal() {
+                    None
+                } else {
+                    match data {
+                        TerminalData::Input(span) => Some(span),
+                        TerminalData::Dynamic(_) => None,
+                    }
+                }
+            }
+            CstNodeData::NonTerminal { .. } => self
+                .children(node_id)
+                .rev()
+                .find_map(|child| self.find_last_non_trivia_span(child)),
+        }
+    }
 }
 
 impl CstFacade for ConcreteSyntaxTree<TerminalKind, NonTerminalKind> {
@@ -552,7 +640,7 @@ impl CstFacade for ConcreteSyntaxTree<TerminalKind, NonTerminalKind> {
         ConcreteSyntaxTree::has_no_children(self, node)
     }
 
-    fn children(&self, node: CstNodeId) -> impl Iterator<Item = CstNodeId> {
+    fn children(&self, node: CstNodeId) -> impl DoubleEndedIterator<Item = CstNodeId> {
         ConcreteSyntaxTree::children(self, node)
     }
 
@@ -827,65 +915,4 @@ pub trait RecursiveView<F: CstFacade> {
         tree: &F,
         visit_ignored: &mut impl BuiltinTerminalVisitor<E, F>,
     ) -> Result<Vec<Self::Item>, CstConstructError<E>>;
-}
-
-/// Returns a span that excludes leading and trailing trivia (whitespace, newlines, comments).
-///
-/// For terminal nodes:
-/// - Returns None if the terminal is trivia (whitespace, newline, line comment, block comment)
-/// - Returns the terminal's span otherwise
-///
-/// For non-terminal nodes:
-/// - Recursively finds the first and last non-trivia descendant spans
-/// - Returns the merged span of those two endpoints
-/// - Returns None if all descendants are trivia
-///
-/// This is useful when you want to get the "meaningful" span of a syntax node,
-/// excluding any surrounding whitespace or comments.
-pub fn get_shrunk_span<F: CstFacade>(cst: &F, node_id: CstNodeId) -> Option<InputSpan> {
-    let node_data = cst.node_data(node_id)?;
-
-    match node_data {
-        CstNodeData::Terminal { kind, data } => {
-            // If it's trivia, return None
-            if kind.is_builtin_terminal() {
-                return None;
-            }
-            // Otherwise return the span if it's from input
-            match data {
-                TerminalData::Input(span) => Some(span),
-                TerminalData::Dynamic(_) => None,
-            }
-        }
-        CstNodeData::NonTerminal { data, .. } => {
-            // Collect children and find first/last non-trivia spans
-            let children: Vec<_> = cst.children(node_id).collect();
-
-            // Find first non-trivia span (from the beginning)
-            let first_span = children
-                .iter()
-                .filter_map(|&child| get_shrunk_span(cst, child))
-                .next();
-
-            // Find last non-trivia span (from the end)
-            let last_span = children
-                .iter()
-                .rev()
-                .filter_map(|&child| get_shrunk_span(cst, child))
-                .next();
-
-            match (first_span, last_span) {
-                (Some(first), Some(last)) => Some(first.merge(last)),
-                (Some(span), None) | (None, Some(span)) => Some(span),
-                (None, None) => {
-                    // All children are trivia or no children
-                    // Fall back to the original span if available
-                    match data {
-                        NonTerminalData::Input(span) if span != InputSpan::EMPTY => Some(span),
-                        _ => None,
-                    }
-                }
-            }
-        }
-    }
 }


### PR DESCRIPTION
Add a function that returns a span excluding leading and trailing trivia
(whitespace, newlines, comments) from non-terminal nodes. This is useful
when you want to get the "meaningful" span of a syntax node.

The function recursively finds the first and last non-trivia descendant
spans and merges them, effectively shrinking the span to exclude
surrounding whitespace and comments.

Includes tests demonstrating the behavior difference between the original
span (which includes trivia) and the shrunk span (which excludes it).