### PR TITLE
fix: remove unused imports in document_to_schema_test.rs

### DIFF
--- a/crates/eure-schema/tests/document_to_schema_test.rs
+++ b/crates/eure-schema/tests/document_to_schema_test.rs
@@ -20,10 +20,9 @@ use eure_schema::{
     SchemaNodeContent, SchemaNodeId, TextSchema, UnknownFieldsPolicy,
 };
 use eure_value::data_model::VariantRepr;
-use eure_value::document::NodeId;
 use eure_value::identifier::Identifier;
 use eure_value::parse::{ParseError, ParseErrorKind};
-use eure_value::value::{ObjectKey, ValueKind};
+use eure_value::value::ObjectKey;
 use num_bigint::BigInt;
 
 // Helper function to parse Eure text and convert to schema

--- a/crates/eure/src/document.rs
+++ b/crates/eure/src/document.rs
@@ -250,10 +250,9 @@ mod tests {
         if let Some(CstNode::NonTerminal {
             kind: node_kind, ..
         }) = cst.node_data(start)
+            && node_kind == kind
         {
-            if node_kind == kind {
-                return Some(start);
-            }
+            return Some(start);
         }
 
         for child in cst.children(start) {


### PR DESCRIPTION
Remove unused imports NodeId and ValueKind that were causing
compiler warnings during cargo test.