### PR TITLE
feat(eure-value): add deferred node creation with origin tracking

### DIFF
--- a/crates/eure-value/src/document.rs
+++ b/crates/eure-value/src/document.rs
@@ -1,5 +1,7 @@
 pub mod constructor;
 pub mod node;
+pub mod origins;
+pub mod segment;
 
 use crate::document::node::{NodeArray, NodeMap, NodeTuple};
 use crate::prelude_internal::*;

--- a/crates/eure-value/src/document/constructor.rs
+++ b/crates/eure-value/src/document/constructor.rs
@@ -1,46 +1,79 @@
 use crate::prelude_internal::*;
 
+use super::origins::NodeOrigins;
+use super::segment::Segment;
+
 #[derive(Debug, PartialEq, thiserror::Error, Clone)]
 pub enum PopError {
     #[error("Cannot pop from root (stack is empty)")]
     CannotPopRoot,
-    #[error("Node ID mismatch: expected {expected:?}, but got {actual:?}")]
-    NodeIdMismatch { expected: NodeId, actual: NodeId },
 }
 
-pub struct DocumentConstructor {
-    document: EureDocument,
-    /// The path from the root to the current node.
-    /// It will contain unused parts after pop operation and those spaces will be used for future push operations.
-    path: Vec<PathSegment>,
-    /// The second element of the tuple indicates the current path range from the root.
-    /// 0 means the root node.
-    stack: Vec<StackItem>,
+#[derive(Debug, PartialEq, thiserror::Error, Clone)]
+pub enum FinishError {
+    #[error("Unconsumed deferred path remains: the last segment was never bound")]
+    UnconsumedDeferredPath,
 }
 
-pub struct StackItem {
-    node_id: NodeId,
-    path_range: usize,
+/// Deferred segment waiting to be consumed by a bind operation or the next push.
+#[derive(Debug, Clone)]
+struct DeferredSegment<O> {
+    path: PathSegment,
+    origin: Option<O>,
 }
 
-impl Default for DocumentConstructor {
-    fn default() -> Self {
-        let document = EureDocument::default();
-        let root = document.get_root_id();
+impl<O> DeferredSegment<O> {
+    fn from_segment(seg: &Segment<O>) -> Self
+    where
+        O: Clone,
+    {
         Self {
-            document,
-            path: vec![],
-            stack: vec![StackItem {
-                node_id: root,
-                path_range: 0,
-            }],
+            path: seg.path.clone(),
+            origin: seg.origin.clone(),
         }
     }
 }
 
-impl DocumentConstructor {
+pub struct DocumentConstructor<O = ()> {
+    document: EureDocument,
+    /// The path from the root to the current node.
+    path: Vec<PathSegment>,
+    /// Stack tracking the current position in the document tree.
+    stack: Vec<StackItem>,
+    /// Deferred segment waiting to be consumed.
+    deferred: Option<DeferredSegment<O>>,
+    /// Origin tracking for nodes and keys.
+    origins: NodeOrigins<O>,
+}
+
+struct StackItem {
+    node_id: NodeId,
+    path_range: usize,
+}
+
+impl<O> Default for DocumentConstructor<O> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<O> DocumentConstructor<O> {
     pub fn new() -> Self {
-        Self::default()
+        let mut document = EureDocument::default();
+        // Initialize root as Null instead of Uninitialized
+        let root_id = document.get_root_id();
+        document.node_mut(root_id).content = NodeValue::Primitive(PrimitiveValue::Null);
+
+        Self {
+            document,
+            path: vec![],
+            stack: vec![StackItem {
+                node_id: root_id,
+                path_range: 0,
+            }],
+            deferred: None,
+            origins: NodeOrigins::<O>::new(),
+        }
     }
 
     pub fn current_node_id(&self) -> NodeId {
@@ -73,131 +106,302 @@ impl DocumentConstructor {
         &mut self.document
     }
 
-    pub fn finish(mut self) -> EureDocument {
-        // If the root node is Uninitialized, replace it with Null
-        let root_id = self.document.get_root_id();
-        let root_node = self.document.node_mut(root_id);
-        if matches!(root_node.content, NodeValue::Uninitialized) {
-            root_node.content = NodeValue::Primitive(PrimitiveValue::Null);
+    pub fn origins(&self) -> &NodeOrigins<O> {
+        &self.origins
+    }
+
+    /// Finish construction and return the document with origins.
+    ///
+    /// Returns an error if there's an unconsumed deferred segment.
+    pub fn finish(self) -> Result<(EureDocument, NodeOrigins<O>), FinishError> {
+        if self.deferred.is_some() {
+            return Err(FinishError::UnconsumedDeferredPath);
         }
-        self.document
+        Ok((self.document, self.origins))
+    }
+
+    /// Finish construction and return only the document.
+    ///
+    /// Returns an error if there's an unconsumed deferred segment.
+    pub fn finish_document(self) -> Result<EureDocument, FinishError> {
+        self.finish().map(|(doc, _)| doc)
     }
 }
 
-impl DocumentConstructor {
-    pub fn push_path(&mut self, path: &[PathSegment]) -> Result<NodeId, InsertError> {
-        let target = self.current_node_id();
+/// Infer the container type that should hold a child with the given segment type.
+fn infer_container_from(segment: &PathSegment) -> NodeValue {
+    match segment {
+        PathSegment::Ident(_) | PathSegment::Extension(_) | PathSegment::Value(_) => {
+            NodeValue::Map(Default::default())
+        }
+        PathSegment::ArrayIndex(_) => NodeValue::Array(Default::default()),
+        PathSegment::TupleIndex(_) => NodeValue::Tuple(Default::default()),
+    }
+}
+
+impl<O: Clone> DocumentConstructor<O> {
+    /// Consume the deferred segment, creating a node with the container type
+    /// inferred from the next segment.
+    fn consume_deferred_with_next(
+        &mut self,
+        next_segment: &PathSegment,
+    ) -> Result<(), InsertError> {
+        if let Some(deferred) = self.deferred.take() {
+            let container = infer_container_from(next_segment);
+            self.create_and_push_child(deferred.path, container, deferred.origin)?;
+        }
+        Ok(())
+    }
+
+    /// Consume the deferred segment with a specific value.
+    fn consume_deferred_with_value(&mut self, value: NodeValue) -> Result<(), InsertError> {
+        if let Some(deferred) = self.deferred.take() {
+            self.create_and_push_child(deferred.path, value, deferred.origin)?;
+        }
+        Ok(())
+    }
+
+    /// Create a child node and push it onto the stack.
+    fn create_and_push_child(
+        &mut self,
+        segment: PathSegment,
+        content: NodeValue,
+        origin: Option<O>,
+    ) -> Result<NodeId, InsertError> {
+        let parent_id = self.current_node_id();
         let base_path = EurePath::from_iter(self.current_path().iter().cloned());
-        let node_id = self
-            .document
-            .prepare_node_from(target, base_path, path)?
-            .node_id;
-        // Truncate path to current range before extending to avoid keeping stale segments
+
+        // Create the node with the given content
+        let node_id = self.document.create_node(content);
+
+        // Add the child to the parent based on segment type
+        self.add_child_to_parent(parent_id, &segment, node_id, &base_path)?;
+
+        // Record origin if present
+        if let Some(origin) = origin {
+            self.origins.record_node_origin(node_id, origin);
+        }
+
+        // Update path and stack
         let current_range = self.stack.last().map(|item| item.path_range).unwrap_or(0);
         self.path.truncate(current_range);
-        self.path.extend(path.iter().cloned());
+        self.path.push(segment);
         self.stack.push(StackItem {
             node_id,
             path_range: self.path.len(),
         });
+
         Ok(node_id)
     }
 
-    /// Push a binding path for assignment operations (e.g., `a.b.c = value`).
-    ///
-    /// Creates the path if it doesn't exist. Returns an error if the target node
-    /// already has a value assigned to it.
-    ///
-    /// # Example
-    ///
-    /// For `a.b.c = { x = 1 }`:
-    /// - Call `push_binding_path(&[a, b, c])` to set up the binding target
-    /// - Then call `push_path(&[x])` to build the value structure
-    pub fn push_binding_path(&mut self, path: &[PathSegment]) -> Result<NodeId, InsertError> {
-        let node_id = self.push_path(path)?;
+    /// Add a child node to a parent based on the segment type.
+    fn add_child_to_parent(
+        &mut self,
+        parent_id: NodeId,
+        segment: &PathSegment,
+        child_id: NodeId,
+        base_path: &EurePath,
+    ) -> Result<(), InsertError> {
+        let parent = self.document.node_mut(parent_id);
 
-        // Check if the target node already has a value
-        let node = self.document.node(node_id);
-        if !matches!(node.content, NodeValue::Uninitialized) {
-            self.stack.pop(); // Cancel the push_path
+        let map_err = |kind: InsertErrorKind| InsertError {
+            kind,
+            path: base_path.clone(),
+        };
+
+        let result = match segment {
+            PathSegment::Ident(identifier) => {
+                let map = parent.require_map().map_err(map_err)?;
+                map.add(ObjectKey::String(identifier.clone().into_string()), child_id)
+            }
+            PathSegment::Value(object_key) => {
+                let map = parent.require_map().map_err(map_err)?;
+                map.add(object_key.clone(), child_id)
+            }
+            PathSegment::Extension(identifier) => {
+                if parent.extensions.contains_key(identifier) {
+                    return Err(InsertError {
+                        kind: InsertErrorKind::AlreadyAssignedExtension {
+                            identifier: identifier.clone(),
+                        },
+                        path: base_path.clone(),
+                    });
+                }
+                parent.extensions.insert(identifier.clone(), child_id);
+                Ok(())
+            }
+            PathSegment::TupleIndex(index) => {
+                let tuple = parent.require_tuple().map_err(map_err)?;
+                tuple.add_at(*index, child_id)
+            }
+            PathSegment::ArrayIndex(index) => {
+                let array = parent.require_array().map_err(map_err)?;
+                if let Some(idx) = index {
+                    array.add_at(*idx, child_id)
+                } else {
+                    array.push(child_id)
+                }
+            }
+        };
+
+        result.map_err(|kind| InsertError {
+            kind,
+            path: base_path.clone(),
+        })
+    }
+
+    /// Try to get an existing child node for the given segment.
+    fn try_get_child(&self, segment: &PathSegment) -> Option<NodeId> {
+        let node = self.current_node();
+        match segment {
+            PathSegment::Ident(identifier) => node
+                .as_map()
+                .and_then(|m| m.get(&ObjectKey::String(identifier.clone().into_string()))),
+            PathSegment::Value(object_key) => node.as_map().and_then(|m| m.get(object_key)),
+            PathSegment::Extension(identifier) => node.get_extension(identifier),
+            PathSegment::TupleIndex(index) => node.as_tuple().and_then(|t| t.get(*index as usize)),
+            PathSegment::ArrayIndex(Some(index)) => node.as_array().and_then(|a| a.get(*index)),
+            PathSegment::ArrayIndex(None) => None, // push always creates new
+        }
+    }
+
+    /// Move to an existing node (push it onto the stack).
+    fn move_to_existing(&mut self, node_id: NodeId, segment: PathSegment, origin: Option<O>) {
+        // Record origin if present
+        if let Some(origin) = origin {
+            self.origins.record_node_origin(node_id, origin);
+        }
+
+        // Update path and stack
+        let current_range = self.stack.last().map(|item| item.path_range).unwrap_or(0);
+        self.path.truncate(current_range);
+        self.path.push(segment);
+        self.stack.push(StackItem {
+            node_id,
+            path_range: self.path.len(),
+        });
+    }
+
+    /// Push a path for navigation (e.g., section headers).
+    ///
+    /// - If a node exists at the segment, moves to it.
+    /// - If no node exists, defers the segment creation until the next operation.
+    pub fn push_path(&mut self, segments: &[Segment<O>]) -> Result<(), InsertError> {
+        for (i, seg) in segments.iter().enumerate() {
+            // First, consume any pending deferred segment
+            // by inferring its type from the current segment
+            self.consume_deferred_with_next(&seg.path)?;
+
+            let is_last = i == segments.len() - 1;
+
+            if let Some(existing) = self.try_get_child(&seg.path) {
+                // Existing node found - move to it
+                self.move_to_existing(existing, seg.path.clone(), seg.origin.clone());
+            } else if is_last {
+                // Last segment with no existing node - defer
+                self.deferred = Some(DeferredSegment::from_segment(seg));
+            } else {
+                // Intermediate segment with no existing node - defer
+                // It will be consumed by the next iteration
+                self.deferred = Some(DeferredSegment::from_segment(seg));
+            }
+        }
+        Ok(())
+    }
+
+    /// Push a binding path for assignment operations (e.g., `key = value`).
+    ///
+    /// - Intermediate segments are handled like `push_path`.
+    /// - The last segment is always deferred and must not already exist.
+    pub fn push_binding_path(&mut self, segments: &[Segment<O>]) -> Result<(), InsertError> {
+        if segments.is_empty() {
+            return Ok(());
+        }
+
+        // Handle all but the last segment like push_path
+        let (init, last) = segments.split_at(segments.len() - 1);
+        self.push_path(init)?;
+
+        let last = &last[0];
+
+        // Consume any pending deferred segment
+        self.consume_deferred_with_next(&last.path)?;
+
+        // Check if the last segment already exists
+        if self.try_get_child(&last.path).is_some() {
             return Err(InsertError {
                 kind: InsertErrorKind::BindingTargetHasValue,
                 path: EurePath::from_iter(self.current_path().iter().cloned()),
             });
         }
-        Ok(node_id)
+
+        // Defer the last segment
+        self.deferred = Some(DeferredSegment::from_segment(last));
+        Ok(())
     }
 
-    /// Pop the current segment. the node_id is used to assert the item is intended to be popped.
-    pub fn pop(&mut self, node_id: NodeId) -> Result<(), PopError> {
-        // Check if we can pop (must have more than just root)
+    /// Pop the current position from the stack.
+    pub fn pop(&mut self) -> Result<(), PopError> {
         if self.stack.len() <= 1 {
             return Err(PopError::CannotPopRoot);
         }
-
-        // Check node_id before popping to avoid mutating state on error
-        let current_node_id = self.current_node_id();
-        if current_node_id != node_id {
-            return Err(PopError::NodeIdMismatch {
-                expected: current_node_id,
-                actual: node_id,
-            });
-        }
-
         self.stack.pop();
         Ok(())
     }
 
-    /// Bind a primitive value to the current node. Error if already bound.
-    pub fn bind_primitive(&mut self, value: PrimitiveValue) -> Result<(), InsertError> {
-        let node = self.current_node_mut();
-        if !matches!(node.content, NodeValue::Uninitialized) {
-            return Err(InsertError {
-                kind: InsertErrorKind::BindingTargetHasValue,
-                path: EurePath::from_iter(self.current_path().iter().cloned()),
-            });
-        }
-        node.content = NodeValue::Primitive(value);
-        Ok(())
+    /// Bind a primitive value to the current position.
+    ///
+    /// If there's a deferred segment, it's consumed and a new node is created.
+    /// Otherwise, the current node's value is set (if it's still the default Null).
+    pub fn bind_primitive(&mut self, value: PrimitiveValue) -> Result<NodeId, InsertError> {
+        self.bind_value(NodeValue::Primitive(value))
     }
 
-    /// Bind an empty map to the current node. Error if already bound.
-    pub fn bind_empty_map(&mut self) -> Result<(), InsertError> {
-        let node = self.current_node_mut();
-        if !matches!(node.content, NodeValue::Uninitialized) {
-            return Err(InsertError {
-                kind: InsertErrorKind::BindingTargetHasValue,
-                path: EurePath::from_iter(self.current_path().iter().cloned()),
-            });
-        }
-        node.content = NodeValue::Map(Default::default());
-        Ok(())
+    /// Bind an empty map to the current position.
+    pub fn bind_empty_map(&mut self) -> Result<NodeId, InsertError> {
+        self.bind_value(NodeValue::Map(Default::default()))
     }
 
-    /// Bind an empty array to the current node. Error if already bound.
-    pub fn bind_empty_array(&mut self) -> Result<(), InsertError> {
-        let node = self.current_node_mut();
-        if !matches!(node.content, NodeValue::Uninitialized) {
-            return Err(InsertError {
-                kind: InsertErrorKind::BindingTargetHasValue,
-                path: EurePath::from_iter(self.current_path().iter().cloned()),
-            });
-        }
-        node.content = NodeValue::Array(Default::default());
-        Ok(())
+    /// Bind an empty array to the current position.
+    pub fn bind_empty_array(&mut self) -> Result<NodeId, InsertError> {
+        self.bind_value(NodeValue::Array(Default::default()))
     }
 
-    /// Bind an empty tuple to the current node. Error if already bound.
-    pub fn bind_empty_tuple(&mut self) -> Result<(), InsertError> {
-        let node = self.current_node_mut();
-        if !matches!(node.content, NodeValue::Uninitialized) {
-            return Err(InsertError {
-                kind: InsertErrorKind::BindingTargetHasValue,
-                path: EurePath::from_iter(self.current_path().iter().cloned()),
-            });
+    /// Bind an empty tuple to the current position.
+    pub fn bind_empty_tuple(&mut self) -> Result<NodeId, InsertError> {
+        self.bind_value(NodeValue::Tuple(Default::default()))
+    }
+
+    /// Internal: bind a value, consuming deferred if present.
+    fn bind_value(&mut self, value: NodeValue) -> Result<NodeId, InsertError> {
+        if self.deferred.is_some() {
+            // Consume deferred and create the node with the value
+            let deferred = self.deferred.take().unwrap();
+            let node_id =
+                self.create_and_push_child(deferred.path, value, deferred.origin)?;
+            Ok(node_id)
+        } else {
+            // No deferred - set the current node's value
+            // This is for binding to the root or after push_path to an existing node
+            let node_id = self.current_node_id();
+            let root_id = self.document.get_root_id();
+            let node = self.document.node_mut(node_id);
+
+            // Check if we can bind (only if current value is the default Null for root)
+            // For non-root nodes that were navigated to, they might have content already
+            if !matches!(node.content, NodeValue::Primitive(PrimitiveValue::Null))
+                && node_id == root_id
+            {
+                // Root was already bound to something else
+                return Err(InsertError {
+                    kind: InsertErrorKind::BindingTargetHasValue,
+                    path: EurePath::from_iter(self.current_path().iter().cloned()),
+                });
+            }
+
+            node.content = value;
+            Ok(node_id)
         }
-        node.content = NodeValue::Tuple(Default::default());
-        Ok(())
     }
 }
 
@@ -211,9 +415,13 @@ mod tests {
         parser.parse(s).unwrap()
     }
 
+    fn seg(path: PathSegment) -> Segment<()> {
+        Segment::new(path)
+    }
+
     #[test]
     fn test_new_initializes_at_root() {
-        let constructor = DocumentConstructor::new();
+        let constructor: DocumentConstructor<()> = DocumentConstructor::new();
         let root_id = constructor.document().get_root_id();
 
         assert_eq!(constructor.current_node_id(), root_id);
@@ -222,349 +430,270 @@ mod tests {
 
     #[test]
     fn test_current_node_returns_root_initially() {
-        let constructor = DocumentConstructor::new();
+        let constructor: DocumentConstructor<()> = DocumentConstructor::new();
 
         let node = constructor.current_node();
-        assert!(matches!(node.content, NodeValue::Uninitialized));
+        // Root is now initialized to Null instead of Uninitialized
+        assert!(matches!(
+            node.content,
+            NodeValue::Primitive(PrimitiveValue::Null)
+        ));
     }
 
     #[test]
-    fn test_push_segments_single_ident() {
-        let mut constructor = DocumentConstructor::new();
+    fn test_push_binding_and_bind() {
+        let mut constructor: DocumentConstructor<()> = DocumentConstructor::new();
 
         let identifier = create_identifier("field");
-        let segments = &[PathSegment::Ident(identifier.clone())];
+        let segments = &[seg(PathSegment::Ident(identifier.clone()))];
 
-        let node_id = constructor.push_path(segments).expect("Failed to push");
+        constructor
+            .push_binding_path(segments)
+            .expect("Failed to push");
+
+        // Bind a value
+        let node_id = constructor
+            .bind_primitive(PrimitiveValue::Bool(true))
+            .expect("Failed to bind");
 
         assert_eq!(constructor.current_node_id(), node_id);
-        assert_eq!(constructor.current_path(), segments);
+
+        let node = constructor.document().node(node_id);
+        assert!(matches!(
+            node.content,
+            NodeValue::Primitive(PrimitiveValue::Bool(true))
+        ));
     }
 
     #[test]
-    fn test_push_segments_multiple_times() {
-        let mut constructor = DocumentConstructor::new();
+    fn test_push_path_to_existing() {
+        let mut constructor: DocumentConstructor<()> = DocumentConstructor::new();
 
-        let id1 = create_identifier("field1");
-        let id2 = create_identifier("field2");
-
-        constructor
-            .push_path(&[PathSegment::Ident(id1.clone())])
-            .expect("Failed to push first");
-
-        let node_id2 = constructor
-            .push_path(&[PathSegment::Extension(id2.clone())])
-            .expect("Failed to push second");
-
-        assert_eq!(constructor.current_node_id(), node_id2);
-        assert_eq!(
-            constructor.current_path(),
-            &[PathSegment::Ident(id1), PathSegment::Extension(id2)]
-        );
-    }
-
-    #[test]
-    fn test_push_segments_error_propagates() {
-        // Try to add tuple index to primitive node (should fail)
-        let mut constructor = DocumentConstructor::new();
-        // First push to the field node
         let identifier = create_identifier("field");
+
+        // First, create the path with a binding
         constructor
-            .push_path(&[PathSegment::Ident(identifier)])
-            .expect("Failed to push");
-        // Set it to Primitive
-        let node_id = constructor.current_node_id();
-        constructor.document_mut().node_mut(node_id).content =
-            NodeValue::Primitive(PrimitiveValue::Null);
+            .push_binding_path(&[seg(PathSegment::Ident(identifier.clone()))])
+            .expect("Failed to push binding");
+        let node_id1 = constructor
+            .bind_primitive(PrimitiveValue::Bool(true))
+            .expect("Failed to bind");
+        constructor.pop().expect("Failed to pop");
 
-        let result = constructor.push_path(&[PathSegment::TupleIndex(0)]);
+        // Now push_path to the same location - should find existing
+        constructor
+            .push_path(&[seg(PathSegment::Ident(identifier.clone()))])
+            .expect("Failed to push path");
 
-        assert_eq!(
-            result.map_err(|e| e.kind),
-            Err(InsertErrorKind::ExpectedTuple)
-        );
+        // Should be at the same node
+        assert_eq!(constructor.current_node_id(), node_id1);
+    }
+
+    #[test]
+    fn test_push_binding_path_already_exists() {
+        let mut constructor: DocumentConstructor<()> = DocumentConstructor::new();
+
+        let identifier = create_identifier("field");
+
+        // First binding
+        constructor
+            .push_binding_path(&[seg(PathSegment::Ident(identifier.clone()))])
+            .expect("Failed to push binding");
+        constructor
+            .bind_primitive(PrimitiveValue::Bool(true))
+            .expect("Failed to bind");
+        constructor.pop().expect("Failed to pop");
+
+        // Second binding to same location should fail
+        let result = constructor.push_binding_path(&[seg(PathSegment::Ident(identifier))]);
+
+        assert_eq!(result.unwrap_err().kind, InsertErrorKind::BindingTargetHasValue);
     }
 
     #[test]
     fn test_pop_success() {
-        let mut constructor = DocumentConstructor::new();
+        let mut constructor: DocumentConstructor<()> = DocumentConstructor::new();
         let root_id = constructor.document().get_root_id();
 
         let identifier = create_identifier("field");
-        let node_id = constructor
-            .push_path(&[PathSegment::Ident(identifier.clone())])
-            .expect("Failed to push");
-
-        // Pop with correct node_id
-        let result = constructor.pop(node_id);
-        assert_eq!(result, Ok(()));
-
-        // After pop, should be back at root
-        assert_eq!(constructor.current_node_id(), root_id);
-        assert_eq!(constructor.current_path(), &[]);
-    }
-
-    #[test]
-    fn test_pop_wrong_node_id_fails() {
-        let mut constructor = DocumentConstructor::new();
-
-        let identifier = create_identifier("field");
-        let node_id = constructor
-            .push_path(&[PathSegment::Ident(identifier)])
-            .expect("Failed to push");
-
-        // Try to pop with wrong node_id
-        let wrong_id = NodeId(999);
-        let result = constructor.pop(wrong_id);
-
-        assert_eq!(
-            result,
-            Err(PopError::NodeIdMismatch {
-                expected: node_id,
-                actual: wrong_id
-            })
-        );
-
-        // State should remain unchanged
-        assert_eq!(constructor.current_node_id(), node_id);
-    }
-
-    #[test]
-    fn test_pop_root_fails() {
-        let mut constructor = DocumentConstructor::new();
-        let root_id = constructor.document().get_root_id();
-
-        // Try to pop root (should fail)
-        let result = constructor.pop(root_id);
-
-        assert_eq!(result, Err(PopError::CannotPopRoot));
-
-        // State should remain unchanged
-        assert_eq!(constructor.current_node_id(), root_id);
-    }
-
-    #[test]
-    fn test_push_pop_multiple_levels() {
-        let mut constructor = DocumentConstructor::new();
-        let root_id = constructor.document().get_root_id();
-
-        let id1 = create_identifier("level1");
-        let id2 = create_identifier("level2");
-        let id3 = create_identifier("level3");
-
-        // Push three levels
-        let node_id1 = constructor
-            .push_path(&[PathSegment::Ident(id1.clone())])
-            .expect("Failed to push level1");
-
-        let node_id2 = constructor
-            .push_path(&[PathSegment::Extension(id2.clone())])
-            .expect("Failed to push level2");
-
-        let node_id3 = constructor
-            .push_path(&[PathSegment::Extension(id3.clone())])
-            .expect("Failed to push level3");
-
-        // Verify at deepest level
-        assert_eq!(constructor.current_node_id(), node_id3);
-        assert_eq!(
-            constructor.current_path(),
-            &[
-                PathSegment::Ident(id1.clone()),
-                PathSegment::Extension(id2.clone()),
-                PathSegment::Extension(id3)
-            ]
-        );
-
-        // Pop level 3
-        constructor.pop(node_id3).expect("Failed to pop level3");
-        assert_eq!(constructor.current_node_id(), node_id2);
-        assert_eq!(
-            constructor.current_path(),
-            &[PathSegment::Ident(id1.clone()), PathSegment::Extension(id2)]
-        );
-
-        // Pop level 2
-        constructor.pop(node_id2).expect("Failed to pop level2");
-        assert_eq!(constructor.current_node_id(), node_id1);
-        assert_eq!(constructor.current_path(), &[PathSegment::Ident(id1)]);
-
-        // Pop level 1
-        constructor.pop(node_id1).expect("Failed to pop level1");
-        assert_eq!(constructor.current_node_id(), root_id);
-        assert_eq!(constructor.current_path(), &[]);
-    }
-
-    #[test]
-    fn test_push_multiple_segments_at_once() {
-        let mut constructor = DocumentConstructor::new();
-
-        let id1 = create_identifier("ext1");
-        let id2 = create_identifier("ext2");
-
-        // Push multiple segments at once
-        let segments = &[
-            PathSegment::Extension(id1.clone()),
-            PathSegment::Extension(id2.clone()),
-        ];
-
-        let node_id = constructor.push_path(segments).expect("Failed to push");
-
-        assert_eq!(constructor.current_node_id(), node_id);
-        assert_eq!(constructor.current_path(), segments.as_slice());
-    }
-
-    #[test]
-    fn test_push_binding_path_success() {
-        let mut constructor = DocumentConstructor::new();
-
-        let id1 = create_identifier("field1");
-        let id2 = create_identifier("field2");
-        let path = &[
-            PathSegment::Ident(id1.clone()),
-            PathSegment::Extension(id2.clone()),
-        ];
-
-        // Push a new binding path should succeed
-        let node_id = constructor
-            .push_binding_path(path)
-            .expect("Failed to push binding path");
-
-        assert_eq!(constructor.current_node_id(), node_id);
-        assert_eq!(constructor.current_path(), path.as_slice());
-
-        // The node should be uninitialized
-        let node = constructor.document().node(node_id);
-        assert!(matches!(node.content, NodeValue::Uninitialized));
-    }
-
-    #[test]
-    fn test_push_binding_path_already_bound() {
-        let mut constructor = DocumentConstructor::new();
-        let id1 = create_identifier("parent");
-        let id2 = create_identifier("child");
-
-        // Create parent.$child and assign a value to it
-        let parent_id = constructor
-            .document_mut()
-            .prepare_node(&[PathSegment::Ident(id1.clone())])
-            .expect("Failed to prepare parent")
-            .node_id;
-        let child_id = constructor
-            .document_mut()
-            .prepare_node(&[
-                PathSegment::Ident(id1.clone()),
-                PathSegment::Extension(id2.clone()),
-            ])
-            .expect("Failed to prepare child")
-            .node_id;
-        constructor.document_mut().node_mut(child_id).content =
-            NodeValue::Primitive(PrimitiveValue::Bool(true));
-
-        // Try to bind to the same location from parent (should fail)
         constructor
-            .push_path(&[PathSegment::Ident(id1.clone())])
-            .unwrap();
-
-        let result = constructor.push_binding_path(&[PathSegment::Extension(id2.clone())]);
-
-        assert_eq!(
-            result.unwrap_err().kind,
-            InsertErrorKind::BindingTargetHasValue
-        );
-
-        // After the error, constructor should still be at parent (stack was popped)
-        assert_eq!(constructor.current_node_id(), parent_id);
-        assert_eq!(constructor.current_path(), &[PathSegment::Ident(id1)]);
-    }
-
-    #[test]
-    fn test_bind_primitive_success() {
-        let mut constructor = DocumentConstructor::new();
-        let identifier = create_identifier("field");
-
-        // Push to a field node
-        let node_id = constructor
-            .push_path(&[PathSegment::Ident(identifier)])
+            .push_binding_path(&[seg(PathSegment::Ident(identifier))])
             .expect("Failed to push");
-
-        // Bind a primitive value to the node
-        let result = constructor.bind_primitive(PrimitiveValue::Bool(true));
-        assert_eq!(result, Ok(()));
-
-        // Verify the node content is set to Primitive
-        let node = constructor.document().node(node_id);
-        assert!(matches!(
-            node.content,
-            NodeValue::Primitive(PrimitiveValue::Bool(true))
-        ));
-    }
-
-    #[test]
-    fn test_bind_primitive_already_bound() {
-        let mut constructor = DocumentConstructor::new();
-        let identifier = create_identifier("field");
-
-        // Push to a field node
-        let node_id = constructor
-            .push_path(&[PathSegment::Ident(identifier.clone())])
-            .expect("Failed to push");
-
-        // Set the node to already have a value
-        constructor.document_mut().node_mut(node_id).content =
-            NodeValue::Primitive(PrimitiveValue::Null);
-
-        // Try to bind a primitive value (should fail)
-        let result = constructor.bind_primitive(PrimitiveValue::Bool(false));
-
-        assert_eq!(
-            result.unwrap_err().kind,
-            InsertErrorKind::BindingTargetHasValue
-        );
-
-        // Verify the node content remains unchanged
-        let node = constructor.document().node(node_id);
-        assert!(matches!(
-            node.content,
-            NodeValue::Primitive(PrimitiveValue::Null)
-        ));
-    }
-
-    #[test]
-    fn test_finish_replaces_uninitialized_root_with_null() {
-        let constructor = DocumentConstructor::new();
-
-        // Root should be Uninitialized before finish
-        let root_id = constructor.document().get_root_id();
-        assert!(matches!(
-            constructor.document().node(root_id).content,
-            NodeValue::Uninitialized
-        ));
-
-        // After finish, root should be Null
-        let document = constructor.finish();
-        let root_node = document.node(document.get_root_id());
-        assert!(matches!(
-            root_node.content,
-            NodeValue::Primitive(PrimitiveValue::Null)
-        ));
-    }
-
-    #[test]
-    fn test_finish_preserves_initialized_root() {
-        let mut constructor = DocumentConstructor::new();
-
-        // Bind a value to the root
         constructor
             .bind_primitive(PrimitiveValue::Bool(true))
             .expect("Failed to bind");
 
-        // After finish, root should still have the bound value
-        let document = constructor.finish();
-        let root_node = document.node(document.get_root_id());
+        let result = constructor.pop();
+        assert_eq!(result, Ok(()));
+
+        assert_eq!(constructor.current_node_id(), root_id);
+    }
+
+    #[test]
+    fn test_pop_root_fails() {
+        let mut constructor: DocumentConstructor<()> = DocumentConstructor::new();
+
+        let result = constructor.pop();
+        assert_eq!(result, Err(PopError::CannotPopRoot));
+    }
+
+    #[test]
+    fn test_finish_success() {
+        let mut constructor: DocumentConstructor<()> = DocumentConstructor::new();
+
+        constructor
+            .bind_primitive(PrimitiveValue::Bool(true))
+            .expect("Failed to bind");
+
+        let result = constructor.finish();
+        assert!(result.is_ok());
+
+        let (doc, _origins) = result.unwrap();
+        let root = doc.root();
         assert!(matches!(
-            root_node.content,
+            root.content,
             NodeValue::Primitive(PrimitiveValue::Bool(true))
         ));
+    }
+
+    #[test]
+    fn test_finish_with_unconsumed_deferred() {
+        let mut constructor: DocumentConstructor<()> = DocumentConstructor::new();
+
+        let identifier = create_identifier("field");
+        constructor
+            .push_binding_path(&[seg(PathSegment::Ident(identifier))])
+            .expect("Failed to push");
+
+        // Don't bind - leave deferred unconsumed
+        let result = constructor.finish();
+        assert_eq!(result.unwrap_err(), FinishError::UnconsumedDeferredPath);
+    }
+
+    #[test]
+    fn test_nested_binding() {
+        let mut constructor: DocumentConstructor<()> = DocumentConstructor::new();
+
+        let id1 = create_identifier("a");
+        let id2 = create_identifier("b");
+
+        // a.b = true
+        constructor
+            .push_binding_path(&[
+                seg(PathSegment::Ident(id1.clone())),
+                seg(PathSegment::Ident(id2.clone())),
+            ])
+            .expect("Failed to push");
+        constructor
+            .bind_primitive(PrimitiveValue::Bool(true))
+            .expect("Failed to bind");
+        constructor.pop().expect("Failed to pop");
+        constructor.pop().expect("Failed to pop");
+
+        let (doc, _) = constructor.finish().expect("Failed to finish");
+
+        // Verify structure: root.a.b = true
+        let root = doc.root();
+        let a_id = root
+            .as_map()
+            .unwrap()
+            .get(&ObjectKey::String("a".to_string()))
+            .unwrap();
+        let a_node = doc.node(a_id);
+        let b_id = a_node
+            .as_map()
+            .unwrap()
+            .get(&ObjectKey::String("b".to_string()))
+            .unwrap();
+        let b_node = doc.node(b_id);
+        assert!(matches!(
+            b_node.content,
+            NodeValue::Primitive(PrimitiveValue::Bool(true))
+        ));
+    }
+
+    #[test]
+    fn test_array_elements() {
+        let mut constructor: DocumentConstructor<()> = DocumentConstructor::new();
+
+        // Create array with two elements
+        constructor.bind_empty_array().expect("Failed to bind array");
+
+        constructor
+            .push_binding_path(&[seg(PathSegment::ArrayIndex(Some(0)))])
+            .expect("Failed to push");
+        constructor
+            .bind_primitive(PrimitiveValue::Bool(true))
+            .expect("Failed to bind");
+        constructor.pop().expect("Failed to pop");
+
+        constructor
+            .push_binding_path(&[seg(PathSegment::ArrayIndex(Some(1)))])
+            .expect("Failed to push");
+        constructor
+            .bind_primitive(PrimitiveValue::Bool(false))
+            .expect("Failed to bind");
+        constructor.pop().expect("Failed to pop");
+
+        let (doc, _) = constructor.finish().expect("Failed to finish");
+
+        let root = doc.root();
+        let array = root.as_array().unwrap();
+        assert_eq!(array.len(), 2);
+    }
+
+    #[test]
+    fn test_tuple_elements() {
+        let mut constructor: DocumentConstructor<()> = DocumentConstructor::new();
+
+        constructor.bind_empty_tuple().expect("Failed to bind tuple");
+
+        constructor
+            .push_binding_path(&[seg(PathSegment::TupleIndex(0))])
+            .expect("Failed to push");
+        constructor
+            .bind_primitive(PrimitiveValue::Bool(true))
+            .expect("Failed to bind");
+        constructor.pop().expect("Failed to pop");
+
+        constructor
+            .push_binding_path(&[seg(PathSegment::TupleIndex(1))])
+            .expect("Failed to push");
+        constructor
+            .bind_primitive(PrimitiveValue::Bool(false))
+            .expect("Failed to bind");
+        constructor.pop().expect("Failed to pop");
+
+        let (doc, _) = constructor.finish().expect("Failed to finish");
+
+        let root = doc.root();
+        let tuple = root.as_tuple().unwrap();
+        assert_eq!(tuple.len(), 2);
+    }
+
+    #[test]
+    fn test_origin_tracking() {
+        #[derive(Debug, Clone, PartialEq)]
+        struct TestOrigin(u32);
+
+        let mut constructor: DocumentConstructor<TestOrigin> = DocumentConstructor::new();
+
+        let identifier = create_identifier("field");
+        constructor
+            .push_binding_path(&[Segment::with_origin(
+                PathSegment::Ident(identifier),
+                TestOrigin(42),
+            )])
+            .expect("Failed to push");
+        let node_id = constructor
+            .bind_primitive(PrimitiveValue::Bool(true))
+            .expect("Failed to bind");
+        constructor.pop().expect("Failed to pop");
+
+        let (_, origins) = constructor.finish().expect("Failed to finish");
+
+        let node_origins = origins.get_node_origins(node_id).unwrap();
+        assert_eq!(node_origins.len(), 1);
+        assert_eq!(node_origins[0], TestOrigin(42));
     }
 }

--- a/crates/eure-value/src/document/origins.rs
+++ b/crates/eure-value/src/document/origins.rs
@@ -1,0 +1,65 @@
+use alloc::vec::Vec;
+
+use crate::prelude_internal::*;
+
+use super::NodeId;
+
+/// Tracks origin information for nodes and object keys.
+///
+/// - `node_origins`: Maps `NodeId` to a list of origins (a node can have multiple origins)
+/// - `key_origins`: Maps `(NodeId, ObjectKey)` to the origin of that specific map key
+#[derive(Debug, Clone)]
+pub struct NodeOrigins<O> {
+    node_origins: Map<NodeId, Vec<O>>,
+    key_origins: Map<(NodeId, ObjectKey), O>,
+}
+
+impl<O> Default for NodeOrigins<O> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<O> NodeOrigins<O> {
+    pub fn new() -> Self {
+        Self {
+            node_origins: Map::new(),
+            key_origins: Map::new(),
+        }
+    }
+
+    /// Record an origin for a node.
+    pub fn record_node_origin(&mut self, node_id: NodeId, origin: O) {
+        self.node_origins.entry(node_id).or_default().push(origin);
+    }
+
+    /// Record an origin for a map key.
+    pub fn record_key_origin(&mut self, parent_id: NodeId, key: ObjectKey, origin: O) {
+        self.key_origins.insert((parent_id, key), origin);
+    }
+
+    /// Get all origins for a node.
+    pub fn get_node_origins(&self, node_id: NodeId) -> Option<&[O]> {
+        self.node_origins.get(&node_id).map(|v| v.as_slice())
+    }
+
+    /// Get the origin for a specific map key.
+    pub fn get_key_origin(&self, parent_id: NodeId, key: &ObjectKey) -> Option<&O> {
+        self.key_origins.get(&(parent_id, key.clone()))
+    }
+
+    /// Get the underlying node origins map.
+    pub fn node_origins(&self) -> &Map<NodeId, Vec<O>> {
+        &self.node_origins
+    }
+
+    /// Get the underlying key origins map.
+    pub fn key_origins(&self) -> &Map<(NodeId, ObjectKey), O> {
+        &self.key_origins
+    }
+
+    /// Consume and return the underlying maps.
+    pub fn into_parts(self) -> (Map<NodeId, Vec<O>>, Map<(NodeId, ObjectKey), O>) {
+        (self.node_origins, self.key_origins)
+    }
+}

--- a/crates/eure-value/src/document/segment.rs
+++ b/crates/eure-value/src/document/segment.rs
@@ -1,0 +1,31 @@
+use crate::path::PathSegment;
+
+/// A path segment with optional origin information.
+///
+/// Used when constructing documents to track where each segment came from.
+#[derive(Debug, Clone)]
+pub struct Segment<O> {
+    pub path: PathSegment,
+    pub origin: Option<O>,
+}
+
+impl<O> Segment<O> {
+    /// Create a segment without origin information.
+    pub fn new(path: PathSegment) -> Self {
+        Self { path, origin: None }
+    }
+
+    /// Create a segment with origin information.
+    pub fn with_origin(path: PathSegment, origin: O) -> Self {
+        Self {
+            path,
+            origin: Some(origin),
+        }
+    }
+}
+
+impl<O> From<PathSegment> for Segment<O> {
+    fn from(path: PathSegment) -> Self {
+        Self::new(path)
+    }
+}

--- a/crates/eure/src/document.rs
+++ b/crates/eure/src/document.rs
@@ -5,7 +5,10 @@ use eure_parol::EureParseError;
 pub use eure_value::document::*;
 use eure_value::identifier::IdentifierError;
 use eure_value::text::TextParseError;
-use eure_value::{document::constructor::PopError, path::PathSegment};
+use eure_value::{
+    document::constructor::{FinishError, PopError},
+    path::PathSegment,
+};
 
 use crate::document::value_visitor::ValueVisitor;
 use eure_tree::prelude::*;
@@ -166,6 +169,8 @@ pub enum DocumentConstructionError {
     PopPath(#[from] PopError),
     #[error("Failed to parse tuple index: {value}")]
     InvalidTupleIndex { node_id: CstNodeId, value: String },
+    #[error("Failed to finish document: {0}")]
+    FinishError(FinishError),
 }
 
 impl DocumentConstructionError {
@@ -227,7 +232,7 @@ pub fn parse_to_document(
 pub fn cst_to_document(input: &str, cst: &Cst) -> Result<EureDocument, DocumentConstructionError> {
     let mut visitor = ValueVisitor::new(input);
     visitor.visit_root_handle(cst.root_handle(), cst)?;
-    Ok(visitor.into_document())
+    visitor.into_document()
 }
 
 /// Parse CST to document and collect origin information for span resolution.
@@ -237,7 +242,7 @@ pub fn cst_to_document_and_origins(
 ) -> Result<(EureDocument, NodeOriginMap), DocumentConstructionError> {
     let mut visitor = ValueVisitor::new(input);
     visitor.visit_root_handle(cst.root_handle(), cst)?;
-    Ok(visitor.into_document_and_origins())
+    visitor.into_document_and_origins()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Add Segment<O> struct for path segments with optional origin
- Add NodeOrigins<O> for tracking node and key origins
- Make DocumentConstructor generic over origin type O
- Implement deferred node creation in push_path/push_binding_path
- Change finish() to return Result with FinishError for unconsumed deferred
- Remove NodeId from pop() signature

This is a work-in-progress toward eliminating NodeValue::Uninitialized.
The eure crate's ValueVisitor still needs to be updated to use the new API.