### PR TITLE
refactor(eure-document): remove Value type in favor of EureDocument

### DIFF
--- a/crates/eure-document/src/data_model.rs
+++ b/crates/eure-document/src/data_model.rs
@@ -84,6 +84,7 @@ pub enum VariantRepr {
 
 impl VariantRepr {
     /// Create a VariantRepr from $variant-repr annotation node
+    // FIXME: Use ParseDocument
     pub fn from_annotation(doc: &EureDocument, node_id: NodeId) -> Option<Self> {
         let node = doc.node(node_id);
         match &node.content {

--- a/crates/eure-document/src/document.rs
+++ b/crates/eure-document/src/document.rs
@@ -7,7 +7,7 @@ use crate::prelude_internal::*;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct NodeId(pub usize);
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EureDocument {
     pub(crate) root: NodeId,
     nodes: Vec<Node>,
@@ -210,6 +210,11 @@ impl EureDocument {
 
     pub fn create_node_uninitialized(&mut self) -> NodeId {
         self.create_node(NodeValue::Hole)
+    }
+
+    /// Set the content of a node directly
+    pub fn set_content(&mut self, node_id: NodeId, content: NodeValue) {
+        self.nodes[node_id.0].content = content;
     }
 
     pub fn add_child_by_segment(

--- a/crates/eure-document/src/document/node.rs
+++ b/crates/eure-document/src/document/node.rs
@@ -1,6 +1,6 @@
 use crate::{prelude_internal::*, value::ValueKind};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// A node in the Eure document.
 ///
 /// This does not implement PartialEq since content may refer to other nodes, and so equality is not well-defined.

--- a/crates/eure-document/src/lib.rs
+++ b/crates/eure-document/src/lib.rs
@@ -47,8 +47,7 @@ pub(crate) mod prelude_internal {
     pub use crate::identifier::Identifier;
     pub use crate::path::{EurePath, PathSegment};
     pub use crate::text::{Language, SyntaxHint, Text, TextParseError};
-    pub use crate::value::PrimitiveValue;
-    pub use crate::value::{ObjectKey, Value};
+    pub use crate::value::{ObjectKey, PrimitiveValue};
     pub use alloc::boxed::Box;
     pub use alloc::{string::String, string::ToString, vec, vec::Vec};
     pub use thisisplural::Plural;

--- a/crates/eure-document/src/parse.rs
+++ b/crates/eure-document/src/parse.rs
@@ -128,11 +128,8 @@ pub enum ParseErrorKind {
     AmbiguousUnion(Vec<String>),
 
     /// Literal value mismatch.
-    #[error("literal value mismatch: expected {expected:?}, got {actual:?}]")]
-    LiteralMismatch {
-        expected: Box<Value>,
-        actual: Box<Value>,
-    },
+    #[error("literal value mismatch: expected {expected}, got {actual}")]
+    LiteralMismatch { expected: String, actual: String },
 }
 
 impl ParseErrorKind {
@@ -448,7 +445,7 @@ pub struct LiteralParser<T>(T);
 
 impl<'doc, T> DocumentParser<'doc> for LiteralParser<T>
 where
-    T: 'doc + ParseDocument<'doc> + PartialEq + Into<Value>,
+    T: 'doc + ParseDocument<'doc> + PartialEq + core::fmt::Debug,
 {
     type Output = T;
     fn parse(self, doc: &'doc EureDocument, node_id: NodeId) -> Result<Self::Output, ParseError> {
@@ -459,8 +456,8 @@ where
             Err(ParseError {
                 node_id,
                 kind: ParseErrorKind::LiteralMismatch {
-                    expected: Box::new(self.0.into()),
-                    actual: Box::new(value.into()),
+                    expected: format!("{:?}", self.0),
+                    actual: format!("{:?}", value),
                 },
             })
         }

--- a/crates/eure-document/src/parse.rs
+++ b/crates/eure-document/src/parse.rs
@@ -129,6 +129,7 @@ pub enum ParseErrorKind {
 
     /// Literal value mismatch.
     #[error("literal value mismatch: expected {expected}, got {actual}")]
+    // FIXME: Use EureDocument instead of String?
     LiteralMismatch { expected: String, actual: String },
 }
 

--- a/crates/eure-document/src/value.rs
+++ b/crates/eure-document/src/value.rs
@@ -11,7 +11,6 @@ pub enum ValueKind {
     F32,
     F64,
     Text,
-    Variant,
     Array,
     Tuple,
     Map,
@@ -27,7 +26,6 @@ impl core::fmt::Display for ValueKind {
             Self::F32 => write!(f, "f32"),
             Self::F64 => write!(f, "f64"),
             Self::Text => write!(f, "text"),
-            Self::Variant => write!(f, "variant"),
             Self::Array => write!(f, "array"),
             Self::Tuple => write!(f, "tuple"),
             Self::Map => write!(f, "map"),
@@ -48,7 +46,6 @@ pub enum PrimitiveValue {
     /// - `` `...` `` syntax produces `Text` with `Language::Implicit`
     /// - `` lang`...` `` syntax produces `Text` with `Language::Other(lang)`
     Text(Text),
-    Variant(Variant),
 }
 
 impl PrimitiveValue {
@@ -74,17 +71,8 @@ impl PrimitiveValue {
             Self::F32(_) => ValueKind::F32,
             Self::F64(_) => ValueKind::F64,
             Self::Text(_) => ValueKind::Text,
-            Self::Variant(_) => ValueKind::Variant,
         }
     }
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum Value {
-    Primitive(PrimitiveValue),
-    Array(Array),
-    Tuple(Tuple<Value>),
-    Map(Map),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -160,9 +148,6 @@ impl From<BigInt> for ObjectKey {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Plural, Default)]
-pub struct Array(pub Vec<Value>);
-
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Plural, Default)]
 pub struct Tuple<T>(pub Vec<T>);
 
@@ -177,16 +162,6 @@ impl core::fmt::Display for Tuple<ObjectKey> {
         }
         write!(f, ")")
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Plural, Default)]
-#[plural(len, is_empty, iter, into_iter, into_iter_ref, from_iter, new)]
-pub struct Map(pub crate::Map<ObjectKey, Value>);
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct Variant {
-    pub tag: String,
-    pub content: Box<Value>,
 }
 
 // ============================================================================

--- a/crates/eure-schema/src/lib.rs
+++ b/crates/eure-schema/src/lib.rs
@@ -34,8 +34,8 @@ pub mod parse;
 pub mod validate;
 
 use eure_document::data_model::VariantRepr;
+use eure_document::document::EureDocument;
 use eure_document::identifier::Identifier;
-use eure_document::value::Value;
 use num_bigint::BigInt;
 use std::collections::HashMap;
 
@@ -123,7 +123,7 @@ pub enum SchemaNodeContent {
     // --- Literal ---
     /// Literal type - accepts only the exact specified value
     /// Spec: line 396
-    Literal(Value),
+    Literal(EureDocument),
 
     // --- Compounds ---
     /// Array type with item schema and optional constraints
@@ -493,7 +493,7 @@ pub struct SchemaMetadata {
     /// Marks as deprecated
     pub deprecated: bool,
     /// Default value for optional fields
-    pub default: Option<Value>,
+    pub default: Option<EureDocument>,
     /// Example values in Eure code format
     pub examples: Option<Vec<String>>,
 }

--- a/crates/eure-schema/src/parse.rs
+++ b/crates/eure-schema/src/parse.rs
@@ -636,7 +636,6 @@ fn get_variant_string(doc: &EureDocument, node_id: NodeId) -> Result<Option<Stri
             let node = doc.node(var_node_id);
             match &node.content {
                 NodeValue::Primitive(PrimitiveValue::Text(t)) => Ok(Some(t.as_str().to_string())),
-                NodeValue::Primitive(PrimitiveValue::Variant(v)) => Ok(Some(v.tag.clone())),
                 _ => Err(ParseError {
                     node_id: var_node_id,
                     kind: ParseErrorKind::TypeMismatch {

--- a/crates/eure-schema/src/validate.rs
+++ b/crates/eure-schema/src/validate.rs
@@ -1661,6 +1661,7 @@ fn are_nodes_unique(document: &EureDocument, node_ids: &[NodeId]) -> bool {
         .iter()
         .map(|&id| node_subtree_to_document(document, id))
         .collect();
+    // FIXME: Inefficient and not idiomatic.
     for i in 0..docs.len() {
         for j in (i + 1)..docs.len() {
             if docs[i] == docs[j] {


### PR DESCRIPTION
- Remove `Value`, `Array`, `Map`, and `Variant` types from eure-document
- Remove `PrimitiveValue::Variant` - variants now use `$variant` extension
- Change `SchemaNodeContent::Literal` to use `EureDocument` instead of `Value`
- Update validation to compare `EureDocument` instances directly
- Update eure-json to handle variants via `$variant` extension pattern
- Update eure-json-schema to use document-based literal conversion
- Add `Clone` derive to `EureDocument` and `Node` for subtree extraction
- Add `set_content` method to `EureDocument` for node manipulation

This simplifies the data model by eliminating the redundant recursive
`Value` type. All value representation now goes through `EureDocument`,
which provides a unified arena-based structure.