### PR TITLE
Consolidate macro value parsing logic

### DIFF
--- a/crates/eure-document/src/eure_macro.rs
+++ b/crates/eure-document/src/eure_macro.rs
@@ -1079,6 +1079,48 @@ mod tests {
         assert_eq!(text.as_str(), "hello");
     }
 
+    #[test]
+    fn test_eure_code_with_language_at_root() {
+        // Test @code("lang", "content") at root level
+        let doc = eure!({
+            = @code("sql", "SELECT 1"),
+        });
+
+        let root_id = doc.get_root_id();
+        let root = doc.node(root_id);
+        let text = root.as_primitive().unwrap().as_text().unwrap();
+        assert_eq!(text.as_str(), "SELECT 1");
+        assert_eq!(text.language.as_str(), Some("sql"));
+    }
+
+    #[test]
+    fn test_eure_block_at_root() {
+        // Test @block("content") at root level
+        let doc = eure!({
+            = @block("fn main() {}"),
+        });
+
+        let root_id = doc.get_root_id();
+        let root = doc.node(root_id);
+        let text = root.as_primitive().unwrap().as_text().unwrap();
+        assert_eq!(text.as_str(), "fn main() {}\n");
+        assert!(text.language.is_implicit());
+    }
+
+    #[test]
+    fn test_eure_block_with_language_at_root() {
+        // Test @block("lang", "content") at root level
+        let doc = eure!({
+            = @block("rust", "fn main() {}"),
+        });
+
+        let root_id = doc.get_root_id();
+        let root = doc.node(root_id);
+        let text = root.as_primitive().unwrap().as_text().unwrap();
+        assert_eq!(text.as_str(), "fn main() {}\n");
+        assert_eq!(text.language.as_str(), Some("rust"));
+    }
+
     // ========================================================================
     // Tests for edge cases and missing coverage
     // ========================================================================


### PR DESCRIPTION
…l rules

- Add @value helper to centralize value-to-expression conversion logic
- Rename internal macro rules for clarity:
  - @body -> @stmt (statement handler)
  - @parse_seg -> @path (path segment parser)
  - @after_seg -> @after_path (post-segment handler)
  - @handle_arr -> @array_marker (array marker handler)
  - @after_arr -> @terminal (terminal/binding handler)
- Update @stmt and @terminal to use @value for consistent value conversion

This reduces duplication of value conversion logic (null, @code, @block) from 12 patterns to 6, while maintaining the two-path structure for root bindings (no scope) and path bindings (with scope).