### PR TITLE
Assert 

### DIFF
--- a/test-suite/cases/eure-schema-to-json-schema/errors/bigint-out-of-range.eure
+++ b/test-suite/cases/eure-schema-to-json-schema/errors/bigint-out-of-range.eure
@@ -5,4 +5,4 @@ $variant = "integer"
 range = "[0, 99999999999999999999999999]"
 ```
 
-json_schema_errors[] = "BigInt"
+json_schema_errors[] = "BigInt value 99999999999999999999999999 is out of range for JSON Schema i64"

--- a/test-suite/cases/eure-schema-to-json-schema/errors/invalid-float-nan.eure
+++ b/test-suite/cases/eure-schema-to-json-schema/errors/invalid-float-nan.eure
@@ -5,4 +5,4 @@ $variant = "float"
 range = "[NaN, 1.0]"
 ```
 
-json_schema_errors[] = "NaN"
+json_schema_errors[] = "Invalid float value: NaN"

--- a/test-suite/cases/eure-schema-to-json-schema/errors/non-string-map-keys.eure
+++ b/test-suite/cases/eure-schema-to-json-schema/errors/non-string-map-keys.eure
@@ -7,4 +7,4 @@ key = `integer`
 value = `text`
 ```
 
-json_schema_errors[] = "non-string keys"
+json_schema_errors[] = "Eure Map with non-string keys cannot be represented in JSON Schema"

--- a/test-suite/cases/eure-schema-to-json-schema/errors/tuple-constraints-not-supported.eure
+++ b/test-suite/cases/eure-schema-to-json-schema/errors/tuple-constraints-not-supported.eure
@@ -5,4 +5,4 @@ $variant = "tuple"
 elements = [`text`, `integer`]
 ```
 
-json_schema_errors[] = "Tuple constraints"
+json_schema_errors[] = "Tuple constraints not fully supported in JSON Schema"

--- a/test-suite/cases/schema/errors/array-item-type-mismatch.eure
+++ b/test-suite/cases/schema/errors/array-item-type-mismatch.eure
@@ -11,5 +11,17 @@ numbers = [`integer`]
 ```
 
 schema_errors = [
-  "Type mismatch: expected integer, got text"
+  ```
+error: Type mismatch: expected integer, got text at path $.numbers[1]
+ --> <input>:2:1
+  |
+2 | numbers[] = "two"
+  | ^^^^^^^^^^^^^^^^^ Type mismatch: expected integer, got text at path $.numbers[1]
+  |
+note: constraint defined here
+ --> <schema>:1:11
+  |
+1 | numbers = [`integer`]
+  |           ----------- constraint defined here
+```
 ]

--- a/test-suite/cases/schema/errors/ext-type-missing-required.eure
+++ b/test-suite/cases/schema/errors/ext-type-missing-required.eure
@@ -1,5 +1,4 @@
 // Invalid: $description is required but not provided
-// NOTE: Currently FAILS because extension validation is not implemented
 
 input_eure = ```eure
 name = "Alice"
@@ -11,5 +10,17 @@ name.$ext-type.description = `text`
 ```
 
 schema_errors = [
-  "Missing required extension"
+  ```
+error: Missing required extension 'description' at path $.name
+ --> <input>:1:1
+  |
+1 | name = "Alice"
+  | ^^^^^^^^^^^^^^ Missing required extension 'description' at path $.name
+  |
+note: constraint defined here
+ --> <schema>:1:1
+  |
+1 | name = `text`
+  | ------------- constraint defined here
+```
 ]

--- a/test-suite/cases/schema/errors/ext-type-type-mismatch.eure
+++ b/test-suite/cases/schema/errors/ext-type-type-mismatch.eure
@@ -1,5 +1,4 @@
 // Invalid: $description is defined as text but given integer
-// NOTE: Currently FAILS because extension type validation is not implemented
 
 input_eure = ```eure
 name = "Alice"
@@ -12,5 +11,17 @@ name.$ext-type.description = `text`
 ```
 
 schema_errors = [
-  "Type mismatch"
+  ```
+error: Type mismatch: expected text, got integer at path $.name.$description
+ --> <input>:1:1
+  |
+1 | name = "Alice"
+  | ^^^^^^^^^^^^^^ Type mismatch: expected text, got integer at path $.name.$description
+  |
+note: constraint defined here
+ --> <schema>:2:1
+  |
+2 | name.$ext-type.description = `text`
+  | ----------------------------------- constraint defined here
+```
 ]

--- a/test-suite/cases/schema/errors/missing-required-field.eure
+++ b/test-suite/cases/schema/errors/missing-required-field.eure
@@ -10,5 +10,5 @@ email = `text`
 ```
 
 schema_errors = [
-  "Missing required field 'email'"
+  "error: Missing required field 'email' at path $\n"
 ]

--- a/test-suite/cases/schema/errors/type-mismatch.eure
+++ b/test-suite/cases/schema/errors/type-mismatch.eure
@@ -9,5 +9,17 @@ name = `text`
 ```
 
 schema_errors = [
-  "Type mismatch: expected text, got integer"
+  ```
+error: Type mismatch: expected text, got integer at path $.name
+ --> <input>:1:1
+  |
+1 | name = 42
+  | ^^^^^^^^^ Type mismatch: expected text, got integer at path $.name
+  |
+note: constraint defined here
+ --> <schema>:1:1
+  |
+1 | name = `text`
+  | ------------- constraint defined here
+```
 ]

--- a/test-suite/src/case.rs
+++ b/test-suite/src/case.rs
@@ -629,19 +629,41 @@ impl SchemaErrorValidationScenario<'_> {
             .map_err(|e| ScenarioError::PreprocessingError {
                 message: format!("{:?}", e),
             })?;
+        let input_cst = self
+            .input
+            .cst()
+            .map_err(|e| ScenarioError::PreprocessingError {
+                message: format!("{:?}", e),
+            })?;
+        let input_origins =
+            self.input
+                .origins()
+                .map_err(|e| ScenarioError::PreprocessingError {
+                    message: format!("{:?}", e),
+                })?;
         let schema_doc = self
             .schema
             .doc()
             .map_err(|e| ScenarioError::PreprocessingError {
                 message: format!("{:?}", e),
             })?;
+        let schema_cst = self
+            .schema
+            .cst()
+            .map_err(|e| ScenarioError::PreprocessingError {
+                message: format!("{:?}", e),
+            })?;
+        let schema_origins =
+            self.schema
+                .origins()
+                .map_err(|e| ScenarioError::PreprocessingError {
+                    message: format!("{:?}", e),
+                })?;
 
         // Convert schema document to SchemaDocument
-        let (schema, _source_map) =
-            eure_schema::convert::document_to_schema(schema_doc).map_err(|e| {
-                ScenarioError::SchemaConversionError {
-                    message: format!("{:?}", e),
-                }
+        let (schema, schema_source_map) = eure_schema::convert::document_to_schema(schema_doc)
+            .map_err(|e| ScenarioError::SchemaConversionError {
+                message: format!("{:?}", e),
             })?;
 
         // Validate document directly
@@ -654,11 +676,49 @@ impl SchemaErrorValidationScenario<'_> {
             });
         }
 
-        // Check that expected errors are present
-        let actual_errors: Vec<String> = result.errors.iter().map(|e| e.to_string()).collect();
+        // Format errors with source spans using plain text (no ANSI colors)
+        let context = eure::error::SchemaErrorContext {
+            doc_source: self.input.input(),
+            doc_path: "<input>",
+            doc_cst: input_cst,
+            doc_origins: input_origins,
+            schema_source: self.schema.input(),
+            schema_path: "<schema>",
+            schema_cst,
+            schema_origins,
+            schema_source_map: &schema_source_map,
+        };
+        let actual_errors: Vec<String> = result
+            .errors
+            .iter()
+            .map(|e| eure::error::format_schema_error_plain(e, &context))
+            .collect();
 
-        for expected in self.expected_errors {
-            let found = actual_errors.iter().any(|actual| actual.contains(expected));
+        // Normalize errors by trimming whitespace for comparison
+        let actual_errors_trimmed: Vec<String> =
+            actual_errors.iter().map(|e| e.trim().to_string()).collect();
+        let expected_errors_trimmed: Vec<String> = self
+            .expected_errors
+            .iter()
+            .map(|e| e.trim().to_string())
+            .collect();
+
+        // Check exact match between expected and actual errors
+        if expected_errors_trimmed.len() != actual_errors_trimmed.len() {
+            return Err(ScenarioError::ExpectedErrorNotFound {
+                expected: format!(
+                    "Expected {} errors, got {}",
+                    expected_errors_trimmed.len(),
+                    actual_errors_trimmed.len()
+                ),
+                actual_errors: actual_errors.clone(),
+            });
+        }
+
+        for expected in &expected_errors_trimmed {
+            let found = actual_errors_trimmed
+                .iter()
+                .any(|actual| actual == expected);
             if !found {
                 return Err(ScenarioError::ExpectedErrorNotFound {
                     expected: expected.clone(),
@@ -793,14 +853,24 @@ impl EureSchemaToJsonSchemaErrorScenario<'_> {
             Err(e) => e.to_string(),
         };
 
-        // Check that expected errors are present
-        for expected in self.expected_errors {
-            if !error.contains(expected) {
-                return Err(ScenarioError::ExpectedErrorNotFound {
-                    expected: expected.clone(),
-                    actual_errors: vec![error.clone()],
-                });
-            }
+        // Check exact match: expect exactly one error that matches (trimmed for whitespace)
+        if self.expected_errors.len() != 1 {
+            return Err(ScenarioError::ExpectedErrorNotFound {
+                expected: format!(
+                    "Expected exactly 1 error specification, got {}",
+                    self.expected_errors.len()
+                ),
+                actual_errors: vec![error.clone()],
+            });
+        }
+
+        let expected = self.expected_errors[0].trim();
+        let actual = error.trim();
+        if actual != expected {
+            return Err(ScenarioError::ExpectedErrorNotFound {
+                expected: expected.to_string(),
+                actual_errors: vec![error],
+            });
         }
 
         Ok(())


### PR DESCRIPTION
- Add format_schema_error_plain function to eure crate for plain text error formatting (no ANSI colors)
- Modify SchemaErrorValidationScenario to use format_schema_error_plain and exact match comparison (with trim for whitespace normalization)
- Modify EureSchemaToJsonSchemaErrorScenario for exact match comparison
- Update all schema/errors/ test case files with full error messages
- Update json-schema/errors/ test case files with exact error messages