### PR TITLE
Fix variant-repr false positive in union schema

### DIFF
--- a/crates/eure-document/src/parse/union.rs
+++ b/crates/eure-document/src/parse/union.rs
@@ -1045,7 +1045,7 @@ mod tests {
             .variant("a", |ctx: &ParseContext<'_>| {
                 let mut rec = ctx.parse_record()?;
                 let value: i64 = rec.parse_field("value")?;
-                rec.allow_unknown_fields();
+                rec.allow_unknown_fields()?;
                 Ok(ReprTestEnum::A { value })
             })
             .variant("b", |ctx: &ParseContext<'_>| {
@@ -1298,7 +1298,7 @@ mod tests {
             .variant("a", |ctx: &ParseContext<'_>| {
                 let mut rec = ctx.parse_record()?;
                 let value: i64 = rec.parse_field("value")?;
-                rec.allow_unknown_fields();
+                rec.allow_unknown_fields()?;
                 Ok(ReprTestEnum::A { value })
             })
             .variant("b", |ctx: &ParseContext<'_>| {

--- a/crates/eure-schema/src/validate/compound.rs
+++ b/crates/eure-schema/src/validate/compound.rs
@@ -84,7 +84,7 @@ impl<'a, 'doc, 's> DocumentParser<'doc> for ArrayValidator<'a, 'doc, 's> {
         for (i, item_id) in items.iter().enumerate() {
             self.ctx.push_path_index(i);
 
-            let item_ctx = self.ctx.document.parse_context(*item_id);
+            let item_ctx = self.ctx.parse_context(*item_id);
             let child_validator = SchemaValidator {
                 ctx: self.ctx,
                 schema_node_id: self.schema.item,
@@ -140,10 +140,14 @@ impl<'a, 'doc, 's> ArrayValidator<'a, 'doc, 's> {
         for &item_id in items {
             // Fork state for trial validation
             let forked_state = self.ctx.fork_state();
-            let trial_ctx =
-                ValidationContext::with_state(self.ctx.document, self.ctx.schema, forked_state);
+            let trial_ctx = ValidationContext::with_state_and_mode(
+                self.ctx.document,
+                self.ctx.schema,
+                forked_state,
+                self.ctx.union_tag_mode,
+            );
 
-            let item_parse_ctx = self.ctx.document.parse_context(item_id);
+            let item_parse_ctx = trial_ctx.parse_context(item_id);
             let child_validator = SchemaValidator {
                 ctx: &trial_ctx,
                 schema_node_id: contains_schema,
@@ -234,7 +238,7 @@ impl<'a, 'doc, 's> DocumentParser<'doc> for MapValidator<'a, 'doc, 's> {
             // Validate value using SchemaValidator
             self.ctx.push_path_key(key);
 
-            let val_ctx = self.ctx.document.parse_context(val_id);
+            let val_ctx = self.ctx.parse_context(val_id);
             let child_validator = SchemaValidator {
                 ctx: self.ctx,
                 schema_node_id: self.schema.value,
@@ -325,7 +329,7 @@ impl<'a, 'doc, 's> DocumentParser<'doc> for TupleValidator<'a, 'doc, 's> {
         {
             self.ctx.push_path_tuple_index(i as u8);
 
-            let elem_ctx = self.ctx.document.parse_context(*item_id);
+            let elem_ctx = self.ctx.parse_context(*item_id);
             let child_validator = SchemaValidator {
                 ctx: self.ctx,
                 schema_node_id: elem_schema,

--- a/crates/eure-schema/src/validate/union.rs
+++ b/crates/eure-schema/src/validate/union.rs
@@ -150,7 +150,12 @@ fn validate_variant<'doc>(
 ) -> Result<(), ValidatorError> {
     // Fork state for trial validation
     let forked_state = ctx.fork_state();
-    let trial_ctx = ValidationContext::with_state(ctx.document, ctx.schema, forked_state);
+    let trial_ctx = ValidationContext::with_state_and_mode(
+        ctx.document,
+        ctx.schema,
+        forked_state,
+        ctx.union_tag_mode,
+    );
 
     let child_validator = SchemaValidator {
         ctx: &trial_ctx,

--- a/test-suite/cases/schema/variant-repr.eure
+++ b/test-suite/cases/schema/variant-repr.eure
@@ -506,3 +506,49 @@ note: constraint defined here
 12 | |     }
    | |_____- constraint defined here
 ```
+
+// ============================================================================
+// Test Case 16: External Repr with map variant - false positive issue
+// When a variant has a map type whose key matches another variant name,
+// external repr incorrectly extracts the map key as variant tag.
+//
+// Data: { a { x = "hello" } }
+// Schema: variants.a = `integer`, variants.b.a.x = `text`
+//
+// External repr extracts "a" as variant name, tries to match variants.a (integer),
+// but content is a map. The data should actually match variants.b.
+// ============================================================================
+
+@ cases.external-map-variant-false-positive
+input_eure = ```eure
+value {
+  a {
+    x = "hello"
+  }
+}
+```
+
+schema = ```eure
+value {
+  $variant = "union"
+  $variant-repr = "external"
+  variants.a = `integer`
+  variants.b.a.x = `text`
+}
+```
+
+schema_errors[] = ```text
+error: Type mismatch: expected integer, got map at path value
+ --> <input>:2:3
+  |
+2 | /   a {
+3 | |     x = "hello"
+4 | |   }
+  | |___^ Type mismatch: expected integer, got map at path value
+  |
+note: constraint defined here
+ --> <schema>:4:3
+  |
+4 |   variants.a = `integer`
+  |   ---------------------- constraint defined here
+```

--- a/test-suite/cases/schema/variant-repr.eure
+++ b/test-suite/cases/schema/variant-repr.eure
@@ -508,18 +508,51 @@ note: constraint defined here
 ```
 
 // ============================================================================
-// Test Case 16: External Repr with map variant - false positive issue
-// When a variant has a map type whose key matches another variant name,
-// external repr incorrectly extracts the map key as variant tag.
+// Variant Repr Edge Cases - Pattern Exploration
+// ============================================================================
 //
-// Data: { a { x = "hello" } }
-// Schema: variants.a = `integer`, variants.b.a.x = `text`
+// These test cases explore edge cases to determine the best specification
+// for variant tag extraction and matching behavior.
 //
-// External repr extracts "a" as variant name, tries to match variants.a (integer),
-// but content is a map. The data should actually match variants.b.
+// Key questions:
+// 1. Should repr-extracted tag be treated as "priority" or "other"?
+// 2. What happens when extracted tag exists in variants but type mismatches?
+// 3. What happens when extracted tag doesn't exist in variants?
+//
+// Current behavior (to be validated/changed):
+// - Tag is extracted eagerly regardless of whether it exists in variants
+// - If tag exists but type mismatches → error (no fallback)
+// - If tag doesn't exist → error (no fallback)
+
+// ============================================================================
+// Test Case 16: External - tag exists in variants, type matches
+// Expected: Match the variant (clear case)
 // ============================================================================
 
-@ cases.external-map-variant-false-positive
+@ cases.repr-edge-external-tag-exists-type-matches
+input_eure = ```eure
+value {
+  a = "hello"
+}
+```
+
+schema = ```eure
+value {
+  $variant = "union"
+  $variant-repr = "external"
+  variants.a = `text`
+  variants.b = `integer`
+}
+```
+
+// No errors - should match variants.a
+
+// ============================================================================
+// Test Case 17: External - tag exists in variants, type mismatches
+// Question: Should this error, or fallback to try other variants?
+// ============================================================================
+
+@ cases.repr-edge-external-tag-exists-type-mismatches
 input_eure = ```eure
 value {
   a {
@@ -537,6 +570,8 @@ value {
 }
 ```
 
+// Current: Error - type mismatch on variants.a
+// Alternative: Could try variants.b and succeed
 schema_errors[] = ```text
 error: Type mismatch: expected integer, got map at path value
  --> <input>:2:3
@@ -551,4 +586,254 @@ note: constraint defined here
   |
 4 |   variants.a = `integer`
   |   ---------------------- constraint defined here
+```
+
+// ============================================================================
+// Test Case 18: External - tag does NOT exist in variants
+// Question: Should this error immediately, or fallback to untagged?
+// ============================================================================
+
+@ cases.repr-edge-external-tag-not-in-variants
+input_eure = ```eure
+value {
+  unknown = "hello"
+}
+```
+
+schema = ```eure
+value {
+  $variant = "union"
+  $variant-repr = "external"
+  variants.a = `text`
+  variants.b = `integer`
+}
+```
+
+// Current: Error - Invalid variant tag 'unknown'
+// Alternative: Could fallback to untagged (but would fail anyway here)
+schema_errors[] = ```text
+error: Invalid variant tag 'unknown' at path value
+ --> <input>:1:1
+  |
+1 | / value {
+2 | |   unknown = "hello"
+3 | | }
+  | |_^ Invalid variant tag 'unknown' at path value
+  |
+note: constraint defined here
+ --> <schema>:1:1
+  |
+1 | / value {
+2 | |   $variant = "union"
+3 | |   $variant-repr = "external"
+4 | |   variants.a = `text`
+5 | |   variants.b = `integer`
+6 | | }
+  | |_- constraint defined here
+```
+
+// ============================================================================
+// Test Case 19: Internal - tag field value exists in variants, type matches
+// ============================================================================
+
+@ cases.repr-edge-internal-tag-exists-type-matches
+input_eure = ```eure
+value {
+  type = "a"
+  data = "hello"
+}
+```
+
+schema = ```eure
+value {
+  $variant = "union"
+  $variant-repr { tag = "type" }
+  variants.a.data = `text`
+  variants.b.data = `integer`
+}
+```
+
+// No errors - should match variants.a
+
+// ============================================================================
+// Test Case 20: Internal - tag field value exists in variants, type mismatches
+// ============================================================================
+
+@ cases.repr-edge-internal-tag-exists-type-mismatches
+input_eure = ```eure
+value {
+  type = "a"
+  data = 42
+}
+```
+
+schema = ```eure
+value {
+  $variant = "union"
+  $variant-repr { tag = "type" }
+  variants.a.data = `text`
+  variants.b.data = `integer`
+}
+```
+
+// Current: Error - type mismatch
+// The tag says "a" but data is integer (matches b's structure)
+schema_errors[] = ```text
+error: Type mismatch: expected text, got integer at path value.data
+ --> <input>:3:3
+  |
+3 |   data = 42
+  |   ^^^^^^^^^ Type mismatch: expected text, got integer at path value.data
+  |
+note: constraint defined here
+ --> <schema>:4:3
+  |
+4 |   variants.a.data = `text`
+  |   ------------------------ constraint defined here
+```
+
+// ============================================================================
+// Test Case 21: Internal - tag field value does NOT exist in variants
+// ============================================================================
+
+@ cases.repr-edge-internal-tag-not-in-variants
+input_eure = ```eure
+value {
+  type = "unknown"
+  data = "hello"
+}
+```
+
+schema = ```eure
+value {
+  $variant = "union"
+  $variant-repr { tag = "type" }
+  variants.a.data = `text`
+  variants.b.data = `integer`
+}
+```
+
+schema_errors[] = ```text
+error: Invalid variant tag 'unknown' at path value
+ --> <input>:1:1
+  |
+1 | / value {
+2 | |   type = "unknown"
+3 | |   data = "hello"
+4 | | }
+  | |_^ Invalid variant tag 'unknown' at path value
+  |
+note: constraint defined here
+ --> <schema>:1:1
+  |
+1 | / value {
+2 | |   $variant = "union"
+3 | |   $variant-repr { tag = "type" }
+4 | |   variants.a.data = `text`
+5 | |   variants.b.data = `integer`
+6 | | }
+  | |_- constraint defined here
+```
+
+// ============================================================================
+// Test Case 22: Internal - tag field does not exist (no type field)
+// Falls back to untagged mode
+// ============================================================================
+
+@ cases.repr-edge-internal-no-tag-field
+input_eure = ```eure
+value {
+  data = "hello"
+}
+```
+
+schema = ```eure
+value {
+  $variant = "union"
+  $variant-repr { tag = "type" }
+  variants.a.data = `text`
+  variants.b.data = `integer`
+}
+```
+
+// No tag field "type" → falls back to untagged
+// In untagged mode, both variants are tried:
+// - variants.a.data = `text` would match (data is text)
+// - variants.b.data = `integer` would not match
+// Current behavior: Error because variants.b is tried first (HashMap order)
+// This shows the issue with untagged fallback - order matters
+schema_errors[] = ```text
+error: Type mismatch: expected integer, got text at path value.data
+ --> <input>:2:3
+  |
+2 |   data = "hello"
+  |   ^^^^^^^^^^^^^^ Type mismatch: expected integer, got text at path value.data
+  |
+note: constraint defined here
+ --> <schema>:5:3
+  |
+5 |   variants.b.data = `integer`
+  |   --------------------------- constraint defined here
+```
+
+// ============================================================================
+// Test Case 23: Adjacent - similar patterns
+// ============================================================================
+
+@ cases.repr-edge-adjacent-tag-exists-type-matches
+input_eure = ```eure
+value {
+  kind = "a"
+  content = "hello"
+}
+```
+
+schema = ```eure
+value {
+  $variant = "union"
+  $variant-repr = { "tag" => "kind", "content" => "content" }
+  variants.a = `text`
+  variants.b = `integer`
+}
+```
+
+// No errors - should match variants.a
+
+@ cases.repr-edge-adjacent-tag-not-in-variants
+input_eure = ```eure
+value {
+  kind = "unknown"
+  content = "hello"
+}
+```
+
+schema = ```eure
+value {
+  $variant = "union"
+  $variant-repr = { "tag" => "kind", "content" => "content" }
+  variants.a = `text`
+  variants.b = `integer`
+}
+```
+
+schema_errors[] = ```text
+error: Invalid variant tag 'unknown' at path value
+ --> <input>:1:1
+  |
+1 | / value {
+2 | |   kind = "unknown"
+3 | |   content = "hello"
+4 | | }
+  | |_^ Invalid variant tag 'unknown' at path value
+  |
+note: constraint defined here
+ --> <schema>:1:1
+  |
+1 | / value {
+2 | |   $variant = "union"
+3 | |   $variant-repr = { "tag" => "kind", "content" => "content" }
+4 | |   variants.a = `text`
+5 | |   variants.b = `integer`
+6 | | }
+  | |_- constraint defined here
 ```

--- a/test-suite/cases/schema/variant-repr.eure
+++ b/test-suite/cases/schema/variant-repr.eure
@@ -9,6 +9,7 @@
 // ============================================================================
 
 @ cases.external-valid
+input_union_tag_mode = "repr"
 input_eure = ```eure
 value {
   success {
@@ -32,7 +33,7 @@ value {
 // ============================================================================
 
 @ cases.internal-valid
-
+input_union_tag_mode = "repr"
 input_eure = ```eure
 value {
   type = "success"
@@ -55,7 +56,7 @@ value {
 // ============================================================================
 
 @ cases.adjacent-valid
-
+input_union_tag_mode = "repr"
 input_eure = ```eure
 value {
   kind = "success"
@@ -99,6 +100,7 @@ value {
 // ============================================================================
 
 @ cases.external-nested
+input_union_tag_mode = "repr"
 input_eure = ```eure
 value {
   outer {
@@ -129,6 +131,7 @@ value {
 // ============================================================================
 
 @ cases.internal-nested
+input_union_tag_mode = "repr"
 input_eure = ```eure
 value {
   type = "wrapper"
@@ -157,6 +160,7 @@ value {
 // ============================================================================
 
 @ cases.variant-agrees
+input_union_tag_mode = "repr"
 input_eure = ```eure
 value {
   $variant = "success"
@@ -180,6 +184,7 @@ value {
 // ============================================================================
 
 @ cases.mixed-repr-nested
+input_union_tag_mode = "repr"
 input_eure = ```eure
 value {
   outer {
@@ -209,6 +214,7 @@ value {
 // ============================================================================
 
 @ cases.variant-path-nested
+input_union_tag_mode = "repr"
 
 input_eure = ```eure
 value {
@@ -242,8 +248,12 @@ value {
 // ============================================================================
 // Test Case 10: Conflicting variant tags ($variant differs from repr extraction)
 // ============================================================================
+// In Repr mode, $variant extension is ignored. Only repr pattern is used.
+// Here the Internal repr extracts "success" from the "type" field, and
+// $variant = "error" is simply ignored - no conflict occurs.
 
-@ cases.conflicting-tags
+@ cases.repr-ignores-variant-extension
+input_union_tag_mode = "repr"
 input_eure = ```eure
 value {
   $variant = "error"
@@ -259,34 +269,14 @@ value {
   variants.error.code = `integer`
 }
 ```
-schema_errors[] = ```text
-error: Conflicting variant tags: $variant = error, repr = success at path value
- --> <input>:1:1
-  |
-1 | / value {
-2 | |   $variant = "error"
-3 | |   type = "success"
-4 | |   message = "ok"
-5 | | }
-  | |_^ Conflicting variant tags: $variant = error, repr = success at path value
-  |
-note: constraint defined here
- --> <schema>:1:1
-  |
-1 | / value {
-2 | |   $variant = "union"
-3 | |   $variant-repr { tag = "type" }
-4 | |   variants.success.message = `text`
-5 | |   variants.error.code = `integer`
-6 | | }
-  | |_- constraint defined here
-```
+// No errors - $variant is ignored in Repr mode, validation uses "success" variant
 
 // ============================================================================
 // Test Case 11: Invalid variant tag (variant name doesn't exist)
 // ============================================================================
 
 @ cases.invalid-variant-name
+input_union_tag_mode = "repr"
 input_eure = ```eure
 value {
   unknown {
@@ -371,6 +361,7 @@ note: constraint defined here
 // ============================================================================
 
 @ cases.external-missing-wrapper
+input_union_tag_mode = "repr"
 input_eure = ```eure
 value {
   message = "direct content without wrapper"
@@ -453,6 +444,7 @@ note: constraint defined here
 // ============================================================================
 
 @ cases.nested-invalid-inner
+input_union_tag_mode = "repr"
 input_eure = ```eure
 value {
   outer {
@@ -530,6 +522,7 @@ note: constraint defined here
 // ============================================================================
 
 @ cases.repr-edge-external-tag-exists-type-matches
+input_union_tag_mode = "repr"
 input_eure = ```eure
 value {
   a = "hello"
@@ -553,6 +546,7 @@ value {
 // ============================================================================
 
 @ cases.repr-edge-external-tag-exists-type-mismatches
+input_union_tag_mode = "repr"
 input_eure = ```eure
 value {
   a {
@@ -594,6 +588,7 @@ note: constraint defined here
 // ============================================================================
 
 @ cases.repr-edge-external-tag-not-in-variants
+input_union_tag_mode = "repr"
 input_eure = ```eure
 value {
   unknown = "hello"
@@ -637,6 +632,7 @@ note: constraint defined here
 // ============================================================================
 
 @ cases.repr-edge-internal-tag-exists-type-matches
+input_union_tag_mode = "repr"
 input_eure = ```eure
 value {
   type = "a"
@@ -660,6 +656,7 @@ value {
 // ============================================================================
 
 @ cases.repr-edge-internal-tag-exists-type-mismatches
+input_union_tag_mode = "repr"
 input_eure = ```eure
 value {
   type = "a"
@@ -697,6 +694,7 @@ note: constraint defined here
 // ============================================================================
 
 @ cases.repr-edge-internal-tag-not-in-variants
+input_union_tag_mode = "repr"
 input_eure = ```eure
 value {
   type = "unknown"
@@ -741,6 +739,7 @@ note: constraint defined here
 // ============================================================================
 
 @ cases.repr-edge-internal-no-tag-field
+input_union_tag_mode = "repr"
 input_eure = ```eure
 value {
   data = "hello"
@@ -781,6 +780,7 @@ note: constraint defined here
 // ============================================================================
 
 @ cases.repr-edge-adjacent-tag-exists-type-matches
+input_union_tag_mode = "repr"
 input_eure = ```eure
 value {
   kind = "a"
@@ -800,6 +800,7 @@ value {
 // No errors - should match variants.a
 
 @ cases.repr-edge-adjacent-tag-not-in-variants
+input_union_tag_mode = "repr"
 input_eure = ```eure
 value {
   kind = "unknown"


### PR DESCRIPTION
When external repr extracts a tag from a single-key map, it may incorrectly identify the key as a variant name even when the data should match a different variant with a map type. This test documents the current behavior where `{ a { x = "hello" } }` is matched against `variants.a = integer` instead of `variants.b.a.x = text`.