### PR TITLE
Add ADR for ObjectKey type design

### DIFF
--- a/crates/eure-document/src/path.rs
+++ b/crates/eure-document/src/path.rs
@@ -167,8 +167,9 @@ mod tests {
 
     #[test]
     fn test_display_bool_key() {
-        let path = EurePath(vec![PathSegment::Value(ObjectKey::Bool(true))]);
-        assert_eq!(format!("{}", path), "true");
+        // Boolean identifiers in key position become string keys
+        let path = EurePath(vec![PathSegment::Value(ObjectKey::String("true".into()))]);
+        assert_eq!(format!("{}", path), "\"true\"");
     }
 
     #[test]

--- a/crates/eure-document/src/value.rs
+++ b/crates/eure-document/src/value.rs
@@ -78,8 +78,8 @@ impl PrimitiveValue {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// Key-comparable value which implements `Eq` and `Hash`.
 ///
-/// Eure restricts map keys to four types — `String`, `Bool`, `Integer`,
-/// and `Tuple<Key...>` — for practical and predictable behavior.
+/// Eure restricts map keys to three types — `String`, `Number` (BigInt),
+/// and `Tuple<ObjectKey>` — for practical and predictable behavior.
 ///
 /// - **Deterministic equality:**
 ///   These types provide stable, well-defined equality and hashing.
@@ -88,14 +88,16 @@ impl PrimitiveValue {
 ///
 /// - **Reliable round-tripping:**
 ///   Keys must serialize and deserialize without losing meaning.
-///   Strings, booleans, integers, and tuples have canonical and
-///   unambiguous textual forms.
+///   Strings, integers, and tuples have canonical and unambiguous textual forms.
 ///
 /// - **Tooling-friendly:**
 ///   This set balances expressiveness and simplicity, making keys easy
 ///   to validate, index, and reason about across implementations.
+///
+/// Note: In key position, `true`, `false`, and `null` are parsed as string
+/// identifiers, not as boolean/null values. For example, `a.true = true`
+/// creates a key `"true"` with boolean value `true`.
 pub enum ObjectKey {
-    Bool(bool),
     Number(BigInt),
     String(String),
     Tuple(Tuple<ObjectKey>),
@@ -104,7 +106,6 @@ pub enum ObjectKey {
 impl core::fmt::Display for ObjectKey {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            ObjectKey::Bool(b) => write!(f, "{}", b),
             ObjectKey::Number(n) => write!(f, "{}", n),
             ObjectKey::String(s) => {
                 write!(f, "\"")?;
@@ -136,7 +137,7 @@ impl From<String> for ObjectKey {
 
 impl From<bool> for ObjectKey {
     fn from(b: bool) -> Self {
-        ObjectKey::Bool(b)
+        ObjectKey::String(if b { "true" } else { "false" }.to_string())
     }
 }
 

--- a/crates/eure-json-schema/src/eure_to_json_schema.rs
+++ b/crates/eure-json-schema/src/eure_to_json_schema.rs
@@ -433,7 +433,6 @@ fn primitive_to_json(val: &PrimitiveValue) -> Result<serde_json::Value, Conversi
 fn object_key_to_string(key: &ObjectKey) -> Result<String, ConversionError> {
     match key {
         ObjectKey::String(s) => Ok(s.clone()),
-        ObjectKey::Bool(b) => Ok(b.to_string()),
         ObjectKey::Number(n) => Ok(n.to_string()),
         ObjectKey::Tuple(_) => Err(ConversionError::NonStringMapKeysNotSupported),
     }

--- a/crates/eure-json/src/lib.rs
+++ b/crates/eure-json/src/lib.rs
@@ -212,7 +212,6 @@ fn convert_node_content_only(
 
 fn convert_object_key(key: &ObjectKey) -> Result<String, EureToJsonError> {
     match key {
-        ObjectKey::Bool(b) => Ok(b.to_string()),
         ObjectKey::Number(n) => Ok(n.to_string()),
         ObjectKey::String(s) => Ok(s.clone()),
         ObjectKey::Tuple(tuple) => {

--- a/crates/eure-schema/src/validate/compound.rs
+++ b/crates/eure-schema/src/validate/compound.rs
@@ -258,7 +258,6 @@ impl<'a, 'doc, 's> MapValidator<'a, 'doc, 's> {
         let valid = match (key, schema_content) {
             (ObjectKey::String(_), SchemaNodeContent::Text(_)) => true,
             (ObjectKey::Number(_), SchemaNodeContent::Integer(_)) => true,
-            (ObjectKey::Bool(_), SchemaNodeContent::Boolean) => true,
             (ObjectKey::Tuple(_), SchemaNodeContent::Tuple(_)) => true,
             (_, SchemaNodeContent::Any) => true, // Any accepts any key type
             _ => false,

--- a/crates/eure/src/document/value_visitor.rs
+++ b/crates/eure/src/document/value_visitor.rs
@@ -618,8 +618,8 @@ impl<F: CstFacade> CstVisitor<F> for ValueVisitor<'_> {
             KeyValueView::Boolean(bool_handle) => {
                 let bool_view = bool_handle.get_view(tree)?;
                 match bool_view {
-                    BooleanView::True(_) => ObjectKey::Bool(true),
-                    BooleanView::False(_) => ObjectKey::Bool(false),
+                    BooleanView::True(_) => ObjectKey::String("true".to_string()),
+                    BooleanView::False(_) => ObjectKey::String("false".to_string()),
                 }
             }
             KeyValueView::Str(str_handle) => {

--- a/docs/adrs/0005-objectkey-design.eure
+++ b/docs/adrs/0005-objectkey-design.eure
@@ -1,0 +1,130 @@
+$schema: ../../assets/schemas/eure-adr.schema.eure
+
+id = "0005-objectkey-design"
+title = "ObjectKey Type Design: Restricted Key Types for Reliable Maps"
+status = "accepted"
+decision-date = `2025-12-11`
+tags = ["data-model", "breaking-change", "simplification", "json-compatibility"]
+
+context = ```markdown
+EURE needs to define what types can be used as map keys (`ObjectKey`). The design
+must balance expressiveness, implementation simplicity, and interoperability with
+JSON/YAML.
+
+Initially, many key types were considered:
+- `null`, `bool`, `i64`, `u64`, `string`, `unit`, `tuple`, `hole`, and even floats
+
+Each candidate has trade-offs:
+
+**Float keys** are problematic due to:
+- NaN != NaN in IEEE 754, making equality unreliable
+- -0.0 vs +0.0 ambiguity
+- Platform-dependent Hash/Eq implementations
+- Serialization rounding (1.0 → "1" or scientific notation)
+
+**Null keys** are semantically awkward:
+- "A value representing absence" as a key is counterintuitive
+- `{ null: 1, "null": 2 }` creates confusion
+
+**Bool keys** provide little value:
+- `{ true: X, false: Y }` is rarely useful in practice
+- `"true"` and `"false"` as string keys cover all real use cases
+- Introduces syntactic ambiguity: is `a.true` a boolean key or string key?
+
+**Unit keys** are too niche:
+- Only one possible value, so effectively a single-element map
+- Limited practical use cases
+
+**Hole keys** are inappropriate:
+- Holes are meta-level markers for incomplete values
+- Equality between holes is undefined (are two holes at different positions equal?)
+
+**Separate i64/u64** creates complexity:
+- Boundary conditions between signed/unsigned
+- JSON round-trip issues with large integers
+- Is `1i64` the same key as `1u64`?
+```
+
+decision = ````markdown
+**ObjectKey is defined with exactly three variants:**
+
+```rust
+pub enum ObjectKey {
+    Number(BigInt),
+    String(String),
+    Tuple(Tuple<ObjectKey>),
+}
+```
+
+**Design principles:**
+
+1. **Keys represent names, not arbitrary values**
+   - String is the primary key type (JSON-compatible)
+   - Integer keys are useful for array-like access patterns
+   - Tuple keys enable multi-dimensional/composite keys
+
+2. **Use BigInt for integers**
+   - Eliminates i64/u64 boundary problems
+   - No overflow concerns
+   - Clean specification: "Integer = arbitrary precision"
+   - Implementations may optimize small integers internally
+
+3. **Reserved words in key position are identifiers**
+   - `true`, `false`, `null` in key position become string keys
+   - Grammar: `KeyIdent: Ident | True | False | Null`
+   - Example: `a.true = true` means key `"true"` with boolean value `true`
+   - No quoting needed: `a.true` instead of `a."true"`
+
+4. **Tuple keys are recursive**
+   - Tuple elements must also be valid ObjectKey types
+   - Enables structured keys like `(x, y)` for coordinates
+   - Equality is lexicographical element comparison
+````
+
+consequences = ```markdown
+**Positive:**
+- Simple, predictable equality and hashing
+- Clean JSON round-trip (all keys become strings in JSON)
+- No edge cases with NaN, ±0, or integer overflow
+- Grammar is unambiguous: key position vs value position
+- Tuple keys provide expressive power for composite keys
+- BigInt future-proofs against 64-bit limitations
+
+**Negative:**
+- Users wanting float keys must stringify them explicitly
+- Bool keys require string form `"true"`/`"false"` (but `true`/`false` work in key position as identifiers)
+- BigInt has slight performance overhead vs native integers
+
+**Migration:**
+- Previous `KeyCmpValue` type with `U64` variant is replaced
+- Code using `ObjectKey::Bool` should use `ObjectKey::String("true".into())` instead
+- The `Bool` variant in current implementation is deprecated and should be removed
+```
+
+alternatives-considered = [
+  ```markdown
+  **Include Bool as a key type**: Rejected because:
+  - `"true"`/`"false"` strings cover all practical use cases
+  - Avoids ambiguity between `a.true` (bool key) vs `a."true"` (string key)
+  - Simplifies JSON round-trip (no bool-to-string conversion needed)
+  ```,
+  ```markdown
+  **Separate i64/u64 key types**: Rejected because:
+  - Creates boundary confusion (is `-1i64` different from `u64::MAX`?)
+  - JSON cannot distinguish integer types
+  - BigInt unifies all integers cleanly
+  ```,
+  ```markdown
+  **Allow null as key**: Rejected because:
+  - Semantically confusing ("absence" as a key?)
+  - Most languages don't allow null keys in maps
+  - No practical use case justifies the complexity
+  ```,
+  ```markdown
+  **Allow float keys**: Rejected because:
+  - NaN != NaN breaks map invariants
+  - ±0 comparison is platform-dependent
+  - Serialization can change key identity (1.0 → "1")
+  - Users can use string representation if needed
+  ```,
+]


### PR DESCRIPTION
Document the decision to restrict ObjectKey to three variants:
- Number(BigInt) - arbitrary precision integers
- String - primary key type for JSON compatibility
- Tuple<ObjectKey> - composite/multi-dimensional keys

Explains why these types were excluded from keys:
- Float: NaN/±0 equality issues, serialization instability
- Bool: String "true"/"false" sufficient, avoids ambiguity
- Null: semantically awkward as a key
- Unit: too niche
- Hole: meta-level marker, not a data value
- Separate i64/u64: BigInt unifies cleanly