### PR TITLE
Add type synthesis module to eure-schema

### DIFF
--- a/crates/eure-document/src/eure_macro.rs
+++ b/crates/eure-document/src/eure_macro.rs
@@ -2056,6 +2056,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::bool_assert_comparison)] // Testing parse_field deserialization returns correct value
     fn test_eure_variable_mixed_with_literals() {
         // Test mixing variables and literals
         let username = "bob";

--- a/crates/eure-document/src/eure_macro.rs
+++ b/crates/eure-document/src/eure_macro.rs
@@ -2000,9 +2000,7 @@ mod tests {
         // Test using a variable for Text value
         use crate::text::Text;
         let code = Text::inline_implicit("fn main() {}");
-        let doc = eure!({
-            snippet = code
-        });
+        let doc = eure!({ snippet = code });
 
         let mut root = doc.parse_context(doc.get_root_id()).parse_record().unwrap();
         let snippet_ctx = root.field("snippet").unwrap();
@@ -2018,9 +2016,7 @@ mod tests {
         let first = "one";
         let second = "two";
         let third = "three";
-        let doc = eure!({
-            items = [first, second, third]
-        });
+        let doc = eure!({ items = [first, second, third] });
 
         let mut root = doc.parse_context(doc.get_root_id()).parse_record().unwrap();
         let items = root.parse_field::<Vec<&str>>("items").unwrap();
@@ -2032,9 +2028,7 @@ mod tests {
         // Test using variables in tuple literals
         let x = 1.5;
         let y = 2.5;
-        let doc = eure!({
-            point = (x, y)
-        });
+        let doc = eure!({ point = (x, y) });
 
         let mut root = doc.parse_context(doc.get_root_id()).parse_record().unwrap();
         let point = root.parse_field::<(f64, f64)>("point").unwrap();
@@ -2132,9 +2126,7 @@ mod tests {
         // Test using PrimitiveValue::Null from a variable
         use crate::value::PrimitiveValue;
         let null_value = PrimitiveValue::Null;
-        let doc = eure!({
-            optional = null_value
-        });
+        let doc = eure!({ optional = null_value });
 
         let mut root = doc.parse_context(doc.get_root_id()).parse_record().unwrap();
         let optional_ctx = root.field("optional").unwrap();

--- a/crates/eure-schema/src/lib.rs
+++ b/crates/eure-schema/src/lib.rs
@@ -31,6 +31,7 @@
 pub mod convert;
 pub mod identifiers;
 pub mod parse;
+pub mod synth;
 pub mod validate;
 
 use eure_document::data_model::VariantRepr;

--- a/crates/eure-schema/src/synth.rs
+++ b/crates/eure-schema/src/synth.rs
@@ -151,7 +151,7 @@ mod tests {
         let doc = EureDocument::new_primitive(PrimitiveValue::Integer(BigInt::from(42)));
         assert_eq!(synth(&doc, doc.get_root_id()), SynthType::Integer);
 
-        let doc = EureDocument::new_primitive(PrimitiveValue::F64(3.14));
+        let doc = EureDocument::new_primitive(PrimitiveValue::F64(2.5));
         assert_eq!(synth(&doc, doc.get_root_id()), SynthType::Float);
 
         let doc = EureDocument::new_primitive(PrimitiveValue::Text(Text::plaintext("hello")));

--- a/crates/eure-schema/src/synth.rs
+++ b/crates/eure-schema/src/synth.rs
@@ -1,0 +1,389 @@
+//! Type Synthesis for Eure Documents
+//!
+//! This module infers types from Eure document values without requiring a schema.
+//! The synthesized types can be used for:
+//! - Generating schema definitions from example data
+//! - Type checking across multiple files
+//! - Editor tooling (hover types, completions)
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use eure_document::document::{EureDocument, NodeId};
+//! use eure_schema::synth::{synth, SynthType};
+//!
+//! let doc = eure!({ name = "Alice", age = 30 });
+//! let ty = synth(&doc, doc.get_root_id());
+//! // ty = Record { name: Text, age: Integer }
+//! ```
+//!
+//! # Unification
+//!
+//! When synthesizing arrays, element types are unified:
+//!
+//! ```rust,ignore
+//! // [ { a = 1 }, { a = "x", b = "y" } ]
+//! // Result: Array<{ a: Integer } | { a: Text, b: Text }>
+//! ```
+//!
+//! Holes are absorbed during unification:
+//!
+//! ```rust,ignore
+//! // [1, !, 3]
+//! // Result: Array<Integer>  (not Array<Integer | Hole>)
+//! ```
+
+mod types;
+mod unify;
+
+pub use types::*;
+pub use unify::unify;
+
+use eure_document::document::node::NodeValue;
+use eure_document::document::{EureDocument, NodeId};
+use eure_document::text::Language;
+use eure_document::value::{ObjectKey, PrimitiveValue};
+
+/// Synthesize a type from a document node.
+///
+/// This function recursively traverses the document structure and infers
+/// the most specific type for each value.
+///
+/// # Arguments
+///
+/// * `doc` - The Eure document containing the node
+/// * `node_id` - The node to synthesize a type for
+///
+/// # Returns
+///
+/// The synthesized type for the node
+pub fn synth(doc: &EureDocument, node_id: NodeId) -> SynthType {
+    let node = doc.node(node_id);
+
+    match &node.content {
+        NodeValue::Hole(ident) => SynthType::Hole(ident.clone()),
+
+        NodeValue::Primitive(prim) => synth_primitive(prim),
+
+        NodeValue::Array(arr) => {
+            if arr.0.is_empty() {
+                SynthType::Array(Box::new(SynthType::Any))
+            } else {
+                let element_types: Vec<_> = arr.0.iter().map(|&id| synth(doc, id)).collect();
+                let unified = element_types
+                    .into_iter()
+                    .reduce(unify)
+                    .unwrap_or(SynthType::Any);
+                SynthType::Array(Box::new(unified))
+            }
+        }
+
+        NodeValue::Tuple(tuple) => {
+            let element_types: Vec<_> = tuple.0.iter().map(|&id| synth(doc, id)).collect();
+            SynthType::Tuple(element_types)
+        }
+
+        NodeValue::Map(map) => {
+            if map.0.is_empty() {
+                SynthType::Record(SynthRecord::empty())
+            } else {
+                let mut fields = Vec::with_capacity(map.0.len());
+                for (key, &value_id) in &map.0 {
+                    let field_name = object_key_to_field_name(key);
+                    let field_type = synth(doc, value_id);
+                    fields.push((field_name, SynthField::required(field_type)));
+                }
+                SynthType::Record(SynthRecord::new(fields))
+            }
+        }
+    }
+}
+
+/// Synthesize type for a primitive value
+fn synth_primitive(prim: &PrimitiveValue) -> SynthType {
+    match prim {
+        PrimitiveValue::Null => SynthType::Null,
+        PrimitiveValue::Bool(_) => SynthType::Boolean,
+        PrimitiveValue::Integer(_) => SynthType::Integer,
+        PrimitiveValue::F32(_) | PrimitiveValue::F64(_) => SynthType::Float,
+        PrimitiveValue::Text(text) => SynthType::Text(synth_text_language(&text.language)),
+    }
+}
+
+/// Extract language from Text value
+fn synth_text_language(lang: &Language) -> Option<String> {
+    match lang {
+        Language::Implicit => None,
+        Language::Plaintext => Some("plaintext".to_string()),
+        Language::Other(lang) => Some(lang.to_string()),
+    }
+}
+
+/// Convert ObjectKey to a field name string
+///
+/// For string keys, returns the raw string.
+/// For other key types, uses the Display representation.
+fn object_key_to_field_name(key: &ObjectKey) -> String {
+    match key {
+        ObjectKey::String(s) => s.clone(),
+        ObjectKey::Number(n) => n.to_string(),
+        ObjectKey::Tuple(t) => format!("{:?}", t), // Fallback for tuple keys
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use eure_document::document::node::NodeArray;
+    use eure_document::eure;
+    use eure_document::text::Text;
+    use eure_document::value::ObjectKey;
+    use num_bigint::BigInt;
+
+    #[test]
+    fn test_synth_primitives() {
+        let doc = EureDocument::new_primitive(PrimitiveValue::Null);
+        assert_eq!(synth(&doc, doc.get_root_id()), SynthType::Null);
+
+        let doc = EureDocument::new_primitive(PrimitiveValue::Bool(true));
+        assert_eq!(synth(&doc, doc.get_root_id()), SynthType::Boolean);
+
+        let doc = EureDocument::new_primitive(PrimitiveValue::Integer(BigInt::from(42)));
+        assert_eq!(synth(&doc, doc.get_root_id()), SynthType::Integer);
+
+        let doc = EureDocument::new_primitive(PrimitiveValue::F64(3.14));
+        assert_eq!(synth(&doc, doc.get_root_id()), SynthType::Float);
+
+        let doc = EureDocument::new_primitive(PrimitiveValue::Text(Text::plaintext("hello")));
+        assert_eq!(
+            synth(&doc, doc.get_root_id()),
+            SynthType::Text(Some("plaintext".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_synth_empty_array() {
+        let doc = eure!({ arr = [] });
+        let root = doc.node(doc.get_root_id());
+        let arr_id = root
+            .as_map()
+            .unwrap()
+            .get(&ObjectKey::String("arr".into()))
+            .unwrap();
+        assert_eq!(
+            synth(&doc, arr_id),
+            SynthType::Array(Box::new(SynthType::Any))
+        );
+    }
+
+    #[test]
+    fn test_synth_homogeneous_array() {
+        let doc = eure!({ arr = [1, 2, 3] });
+        let root = doc.node(doc.get_root_id());
+        let arr_id = root
+            .as_map()
+            .unwrap()
+            .get(&ObjectKey::String("arr".into()))
+            .unwrap();
+        assert_eq!(
+            synth(&doc, arr_id),
+            SynthType::Array(Box::new(SynthType::Integer))
+        );
+    }
+
+    #[test]
+    fn test_synth_heterogeneous_array() {
+        let doc = eure!({ arr = [1, "hello"] });
+        let root = doc.node(doc.get_root_id());
+        let arr_id = root
+            .as_map()
+            .unwrap()
+            .get(&ObjectKey::String("arr".into()))
+            .unwrap();
+        assert_eq!(
+            synth(&doc, arr_id),
+            SynthType::Array(Box::new(SynthType::Union(SynthUnion {
+                variants: vec![
+                    SynthType::Integer,
+                    SynthType::Text(Some("plaintext".to_string()))
+                ]
+            })))
+        );
+    }
+
+    #[test]
+    fn test_synth_tuple() {
+        let doc = eure!({ tup = (1, "hello", true) });
+        let root = doc.node(doc.get_root_id());
+        let tup_id = root
+            .as_map()
+            .unwrap()
+            .get(&ObjectKey::String("tup".into()))
+            .unwrap();
+        assert_eq!(
+            synth(&doc, tup_id),
+            SynthType::Tuple(vec![
+                SynthType::Integer,
+                SynthType::Text(Some("plaintext".to_string())),
+                SynthType::Boolean,
+            ])
+        );
+    }
+
+    #[test]
+    fn test_synth_record() {
+        let doc = eure!({
+            name = "Alice"
+            age = 30
+        });
+        let ty = synth(&doc, doc.get_root_id());
+        let expected = SynthType::Record(SynthRecord::new([
+            (
+                "name".to_string(),
+                SynthField::required(SynthType::Text(Some("plaintext".to_string()))),
+            ),
+            ("age".to_string(), SynthField::required(SynthType::Integer)),
+        ]));
+        assert_eq!(ty, expected);
+    }
+
+    #[test]
+    fn test_synth_array_of_records_union() {
+        // Build [ { a = 1 }, { a = "x", b = "y" } ] programmatically
+        let mut doc = EureDocument::new_empty();
+
+        // Create first record: { a = 1 }
+        let a1_id = doc.create_node(NodeValue::Primitive(PrimitiveValue::Integer(BigInt::from(
+            1,
+        ))));
+        let rec1_id = doc.create_node(NodeValue::Map(eure_document::document::node::NodeMap(
+            [(ObjectKey::String("a".into()), a1_id)]
+                .into_iter()
+                .collect(),
+        )));
+
+        // Create second record: { a = "x", b = "y" }
+        let a2_id = doc.create_node(NodeValue::Primitive(PrimitiveValue::Text(Text::plaintext(
+            "x",
+        ))));
+        let b2_id = doc.create_node(NodeValue::Primitive(PrimitiveValue::Text(Text::plaintext(
+            "y",
+        ))));
+        let rec2_id = doc.create_node(NodeValue::Map(eure_document::document::node::NodeMap(
+            [
+                (ObjectKey::String("a".into()), a2_id),
+                (ObjectKey::String("b".into()), b2_id),
+            ]
+            .into_iter()
+            .collect(),
+        )));
+
+        // Create array
+        let arr_id = doc.create_node(NodeValue::Array(NodeArray(vec![rec1_id, rec2_id])));
+
+        let ty = synth(&doc, arr_id);
+
+        // Different shapes form a union of records
+        let expected = SynthType::Array(Box::new(SynthType::Union(SynthUnion {
+            variants: vec![
+                SynthType::Record(SynthRecord::new([(
+                    "a".to_string(),
+                    SynthField::required(SynthType::Integer),
+                )])),
+                SynthType::Record(SynthRecord::new([
+                    (
+                        "a".to_string(),
+                        SynthField::required(SynthType::Text(Some("plaintext".to_string()))),
+                    ),
+                    (
+                        "b".to_string(),
+                        SynthField::required(SynthType::Text(Some("plaintext".to_string()))),
+                    ),
+                ])),
+            ],
+        })));
+        assert_eq!(ty, expected);
+    }
+
+    #[test]
+    fn test_synth_nested() {
+        let doc = eure!({
+            items = [1, 2]
+            meta {
+                count = 2
+            }
+        });
+        let ty = synth(&doc, doc.get_root_id());
+        let expected = SynthType::Record(SynthRecord::new([
+            (
+                "items".to_string(),
+                SynthField::required(SynthType::Array(Box::new(SynthType::Integer))),
+            ),
+            (
+                "meta".to_string(),
+                SynthField::required(SynthType::Record(SynthRecord::new([(
+                    "count".to_string(),
+                    SynthField::required(SynthType::Integer),
+                )]))),
+            ),
+        ]));
+        assert_eq!(ty, expected);
+    }
+
+    #[test]
+    fn test_synth_hole_absorbed() {
+        // Build [1, !, 3] programmatically (hole should be absorbed)
+        let mut doc = EureDocument::new_empty();
+        let i1 = doc.create_node(NodeValue::Primitive(PrimitiveValue::Integer(BigInt::from(
+            1,
+        ))));
+        let hole = doc.create_node(NodeValue::Hole(None));
+        let i3 = doc.create_node(NodeValue::Primitive(PrimitiveValue::Integer(BigInt::from(
+            3,
+        ))));
+        let arr_id = doc.create_node(NodeValue::Array(NodeArray(vec![i1, hole, i3])));
+
+        assert_eq!(
+            synth(&doc, arr_id),
+            SynthType::Array(Box::new(SynthType::Integer))
+        );
+    }
+
+    #[test]
+    fn test_synth_same_shape_records_merge() {
+        // Build [ { a = 1 }, { a = "x" } ] - same shape, different field types
+        let mut doc = EureDocument::new_empty();
+
+        let a1_id = doc.create_node(NodeValue::Primitive(PrimitiveValue::Integer(BigInt::from(
+            1,
+        ))));
+        let rec1_id = doc.create_node(NodeValue::Map(eure_document::document::node::NodeMap(
+            [(ObjectKey::String("a".into()), a1_id)]
+                .into_iter()
+                .collect(),
+        )));
+
+        let a2_id = doc.create_node(NodeValue::Primitive(PrimitiveValue::Text(Text::plaintext(
+            "x",
+        ))));
+        let rec2_id = doc.create_node(NodeValue::Map(eure_document::document::node::NodeMap(
+            [(ObjectKey::String("a".into()), a2_id)]
+                .into_iter()
+                .collect(),
+        )));
+
+        let arr_id = doc.create_node(NodeValue::Array(NodeArray(vec![rec1_id, rec2_id])));
+
+        // Same shape records should merge, resulting in Record { a: Integer | Text }
+        let expected = SynthType::Array(Box::new(SynthType::Record(SynthRecord::new([(
+            "a".to_string(),
+            SynthField::required(SynthType::Union(SynthUnion {
+                variants: vec![
+                    SynthType::Integer,
+                    SynthType::Text(Some("plaintext".to_string())),
+                ],
+            })),
+        )]))));
+        assert_eq!(synth(&doc, arr_id), expected);
+    }
+}

--- a/crates/eure-schema/src/synth/types.rs
+++ b/crates/eure-schema/src/synth/types.rs
@@ -1,0 +1,367 @@
+//! Synthesized type definitions
+//!
+//! These types represent inferred types from Eure document values,
+//! without the constraint information found in schema types.
+
+use eure_document::identifier::Identifier;
+use std::collections::HashMap;
+use std::fmt;
+
+/// A synthesized type inferred from document values.
+///
+/// Unlike `SchemaNodeContent`, this type does not include validation
+/// constraints (min/max length, patterns, etc.) - it represents only
+/// the structural type of the data.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SynthType {
+    // === Primitives ===
+    /// Null value
+    Null,
+
+    /// Boolean value
+    Boolean,
+
+    /// Integer value (arbitrary precision)
+    Integer,
+
+    /// Floating-point value
+    Float,
+
+    /// Text value with optional language tag
+    ///
+    /// - `None` - implicit/unknown language (from `` `...` ``)
+    /// - `Some("plaintext")` - plaintext (from `"..."`)
+    /// - `Some("rust")` - language-tagged (from `` rust`...` ``)
+    Text(Option<String>),
+
+    // === Compounds ===
+    /// Homogeneous array type
+    Array(Box<SynthType>),
+
+    /// Tuple type (fixed-length, heterogeneous)
+    Tuple(Vec<SynthType>),
+
+    /// Record type (fixed named fields)
+    Record(SynthRecord),
+
+    // === Special ===
+    /// Union of types (structural, not tagged)
+    ///
+    /// Invariants:
+    /// - At least 2 variants
+    /// - No nested unions (flattened)
+    /// - No duplicate variants
+    Union(SynthUnion),
+
+    /// Top type - accepts any value
+    ///
+    /// Used for:
+    /// - Empty arrays: `[]` has type `Array<Any>`
+    /// - Unknown types
+    Any,
+
+    /// Bottom type - no values
+    ///
+    /// Used for contradictions (rare in practice)
+    Never,
+
+    /// Unfilled placeholder
+    ///
+    /// Holes are absorbed during unification:
+    /// `unify(Integer, Hole) = Integer`
+    Hole(Option<Identifier>),
+}
+
+/// A record type with named fields
+#[derive(Debug, Clone, PartialEq)]
+pub struct SynthRecord {
+    /// Field name to field definition
+    pub fields: HashMap<String, SynthField>,
+}
+
+/// A field in a record type
+#[derive(Debug, Clone, PartialEq)]
+pub struct SynthField {
+    /// The type of the field
+    pub ty: SynthType,
+
+    /// Whether the field is optional
+    ///
+    /// Note: In synthesized types, optionality comes from unifying
+    /// records where some have the field and others don't.
+    pub optional: bool,
+}
+
+/// A structural union of types
+///
+/// Unlike schema unions, these are anonymous/structural and don't
+/// have named variants.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SynthUnion {
+    /// The variant types in this union
+    ///
+    /// Invariants:
+    /// - At least 2 elements
+    /// - No `SynthType::Union` elements (flattened)
+    /// - No duplicates
+    pub variants: Vec<SynthType>,
+}
+
+// === Constructors ===
+
+impl SynthRecord {
+    /// Create an empty record
+    pub fn empty() -> Self {
+        Self {
+            fields: HashMap::new(),
+        }
+    }
+
+    /// Create a record from field definitions
+    pub fn new(fields: impl IntoIterator<Item = (String, SynthField)>) -> Self {
+        Self {
+            fields: fields.into_iter().collect(),
+        }
+    }
+}
+
+impl SynthField {
+    /// Create a required field
+    pub fn required(ty: SynthType) -> Self {
+        Self {
+            ty,
+            optional: false,
+        }
+    }
+
+    /// Create an optional field
+    pub fn optional(ty: SynthType) -> Self {
+        Self { ty, optional: true }
+    }
+}
+
+impl SynthUnion {
+    /// Create a union from variants, normalizing as needed
+    ///
+    /// This function:
+    /// - Flattens nested unions
+    /// - Removes duplicates
+    /// - Returns single type if only one variant remains
+    /// - Returns `Never` for empty input
+    pub fn from_variants(variants: impl IntoIterator<Item = SynthType>) -> SynthType {
+        let mut flat: Vec<SynthType> = Vec::new();
+
+        for variant in variants {
+            match variant {
+                // Flatten nested unions
+                SynthType::Union(inner) => {
+                    for v in inner.variants {
+                        if !flat.contains(&v) {
+                            flat.push(v);
+                        }
+                    }
+                }
+                // Skip Never (identity for union)
+                SynthType::Never => {}
+                // Skip Holes (absorbed)
+                SynthType::Hole(_) => {}
+                // Add if not duplicate
+                other => {
+                    if !flat.contains(&other) {
+                        flat.push(other);
+                    }
+                }
+            }
+        }
+
+        match flat.len() {
+            0 => SynthType::Never,
+            1 => flat.pop().unwrap(),
+            _ => SynthType::Union(SynthUnion { variants: flat }),
+        }
+    }
+}
+
+// === Display implementations ===
+
+impl fmt::Display for SynthType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SynthType::Null => write!(f, "null"),
+            SynthType::Boolean => write!(f, "boolean"),
+            SynthType::Integer => write!(f, "integer"),
+            SynthType::Float => write!(f, "float"),
+            SynthType::Text(None) => write!(f, "text"),
+            SynthType::Text(Some(lang)) => write!(f, "text.{}", lang),
+            SynthType::Array(inner) => write!(f, "[{}]", inner),
+            SynthType::Tuple(elems) => {
+                write!(f, "(")?;
+                for (i, elem) in elems.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", elem)?;
+                }
+                write!(f, ")")
+            }
+            SynthType::Record(rec) => write!(f, "{}", rec),
+            SynthType::Union(union) => write!(f, "{}", union),
+            SynthType::Any => write!(f, "any"),
+            SynthType::Never => write!(f, "never"),
+            SynthType::Hole(None) => write!(f, "!"),
+            SynthType::Hole(Some(id)) => write!(f, "!{}", id),
+        }
+    }
+}
+
+impl fmt::Display for SynthRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{{")?;
+        let mut first = true;
+        for (name, field) in &self.fields {
+            if !first {
+                write!(f, ", ")?;
+            }
+            first = false;
+            write!(f, "{}", name)?;
+            if field.optional {
+                write!(f, "?")?;
+            }
+            write!(f, ": {}", field.ty)?;
+        }
+        write!(f, "}}")
+    }
+}
+
+impl fmt::Display for SynthUnion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (i, variant) in self.variants.iter().enumerate() {
+            if i > 0 {
+                write!(f, " | ")?;
+            }
+            write!(f, "{}", variant)?;
+        }
+        Ok(())
+    }
+}
+
+// === Type predicates ===
+
+impl SynthType {
+    /// Check if this is a primitive type
+    pub fn is_primitive(&self) -> bool {
+        matches!(
+            self,
+            SynthType::Null
+                | SynthType::Boolean
+                | SynthType::Integer
+                | SynthType::Float
+                | SynthType::Text(_)
+        )
+    }
+
+    /// Check if this is a compound type
+    pub fn is_compound(&self) -> bool {
+        matches!(
+            self,
+            SynthType::Array(_) | SynthType::Tuple(_) | SynthType::Record(_)
+        )
+    }
+
+    /// Check if this type contains any holes
+    pub fn has_holes(&self) -> bool {
+        match self {
+            SynthType::Hole(_) => true,
+            SynthType::Array(inner) => inner.has_holes(),
+            SynthType::Tuple(elems) => elems.iter().any(|e| e.has_holes()),
+            SynthType::Record(rec) => rec.fields.values().any(|f| f.ty.has_holes()),
+            SynthType::Union(union) => union.variants.iter().any(|v| v.has_holes()),
+            _ => false,
+        }
+    }
+
+    /// Check if this type is complete (no holes, no Any, no Never)
+    pub fn is_complete(&self) -> bool {
+        match self {
+            SynthType::Hole(_) | SynthType::Any | SynthType::Never => false,
+            SynthType::Array(inner) => inner.is_complete(),
+            SynthType::Tuple(elems) => elems.iter().all(|e| e.is_complete()),
+            SynthType::Record(rec) => rec.fields.values().all(|f| f.ty.is_complete()),
+            SynthType::Union(union) => union.variants.iter().all(|v| v.is_complete()),
+            _ => true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_union_flattening() {
+        // Union of unions should flatten
+        let inner = SynthUnion::from_variants([SynthType::Integer, SynthType::Boolean]);
+        let outer = SynthUnion::from_variants([inner, SynthType::Text(None)]);
+
+        match outer {
+            SynthType::Union(u) => {
+                assert_eq!(u.variants.len(), 3);
+                assert!(u.variants.contains(&SynthType::Integer));
+                assert!(u.variants.contains(&SynthType::Boolean));
+                assert!(u.variants.contains(&SynthType::Text(None)));
+            }
+            _ => panic!("Expected Union"),
+        }
+    }
+
+    #[test]
+    fn test_union_dedup() {
+        let union =
+            SynthUnion::from_variants([SynthType::Integer, SynthType::Integer, SynthType::Boolean]);
+
+        match union {
+            SynthType::Union(u) => {
+                assert_eq!(u.variants.len(), 2);
+            }
+            _ => panic!("Expected Union"),
+        }
+    }
+
+    #[test]
+    fn test_union_single_collapses() {
+        let union = SynthUnion::from_variants([SynthType::Integer]);
+        assert_eq!(union, SynthType::Integer);
+    }
+
+    #[test]
+    fn test_union_absorbs_holes() {
+        let union = SynthUnion::from_variants([SynthType::Integer, SynthType::Hole(None)]);
+        assert_eq!(union, SynthType::Integer);
+    }
+
+    #[test]
+    fn test_union_absorbs_never() {
+        let union = SynthUnion::from_variants([SynthType::Integer, SynthType::Never]);
+        assert_eq!(union, SynthType::Integer);
+    }
+
+    #[test]
+    fn test_display() {
+        assert_eq!(SynthType::Integer.to_string(), "integer");
+        assert_eq!(
+            SynthType::Text(Some("rust".to_string())).to_string(),
+            "text.rust"
+        );
+        assert_eq!(
+            SynthType::Array(Box::new(SynthType::Integer)).to_string(),
+            "[integer]"
+        );
+    }
+
+    #[test]
+    fn test_has_holes() {
+        assert!(!SynthType::Integer.has_holes());
+        assert!(SynthType::Hole(None).has_holes());
+        assert!(SynthType::Array(Box::new(SynthType::Hole(None))).has_holes());
+    }
+}

--- a/crates/eure-schema/src/synth/types.rs
+++ b/crates/eure-schema/src/synth/types.rs
@@ -303,15 +303,16 @@ mod tests {
         let inner = SynthUnion::from_variants([SynthType::Integer, SynthType::Boolean]);
         let outer = SynthUnion::from_variants([inner, SynthType::Text(None)]);
 
-        match outer {
-            SynthType::Union(u) => {
-                assert_eq!(u.variants.len(), 3);
-                assert!(u.variants.contains(&SynthType::Integer));
-                assert!(u.variants.contains(&SynthType::Boolean));
-                assert!(u.variants.contains(&SynthType::Text(None)));
-            }
-            _ => panic!("Expected Union"),
-        }
+        assert_eq!(
+            outer,
+            SynthType::Union(SynthUnion {
+                variants: vec![
+                    SynthType::Integer,
+                    SynthType::Boolean,
+                    SynthType::Text(None)
+                ]
+            })
+        );
     }
 
     #[test]
@@ -319,12 +320,12 @@ mod tests {
         let union =
             SynthUnion::from_variants([SynthType::Integer, SynthType::Integer, SynthType::Boolean]);
 
-        match union {
-            SynthType::Union(u) => {
-                assert_eq!(u.variants.len(), 2);
-            }
-            _ => panic!("Expected Union"),
-        }
+        assert_eq!(
+            union,
+            SynthType::Union(SynthUnion {
+                variants: vec![SynthType::Integer, SynthType::Boolean]
+            })
+        );
     }
 
     #[test]

--- a/crates/eure-schema/src/synth/unify.rs
+++ b/crates/eure-schema/src/synth/unify.rs
@@ -1,0 +1,355 @@
+//! Type unification for synthesized types
+//!
+//! Unification finds the least upper bound (join) of two types in the type lattice.
+//! This is used when synthesizing array types from heterogeneous elements.
+//!
+//! # Type Lattice
+//!
+//! ```text
+//!                    Any (top)
+//!                   / | \
+//!           primitives compounds unions
+//!                   \ | /
+//!                 Never (bottom)
+//! ```
+//!
+//! # Unification Rules
+//!
+//! | T1 | T2 | unify(T1, T2) |
+//! |----|----|----|
+//! | T | T | T |
+//! | Any | T | T |
+//! | Never | T | T |
+//! | Hole | T | T |
+//! | Int | Text | Int \| Text |
+//! | Array<A> | Array<B> | Array<unify(A, B)> |
+//! | Tuple(same len) | Tuple | Tuple(elementwise) |
+//! | Record | Record (same shape) | Record |
+//! | Record | Record (diff shape) | Record \| Record |
+//! | otherwise | | Union |
+
+use super::types::{SynthField, SynthRecord, SynthType, SynthUnion};
+
+/// Unify two types into their least upper bound.
+///
+/// This finds the most specific type that is a supertype of both inputs.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// // Same types
+/// unify(Integer, Integer) == Integer
+///
+/// // Different primitives form a union
+/// unify(Integer, Text) == Integer | Text
+///
+/// // Arrays unify element types
+/// unify(Array<Int>, Array<Text>) == Array<Int | Text>
+///
+/// // Holes are absorbed
+/// unify(Integer, Hole) == Integer
+/// ```
+pub fn unify(t1: SynthType, t2: SynthType) -> SynthType {
+    // Fast path: identical types
+    if t1 == t2 {
+        return t1;
+    }
+
+    match (t1, t2) {
+        // Identity elements
+        (SynthType::Any, t) | (t, SynthType::Any) => t,
+        (SynthType::Never, t) | (t, SynthType::Never) => t,
+        (SynthType::Hole(_), t) | (t, SynthType::Hole(_)) => t,
+
+        // Union flattening
+        (SynthType::Union(u1), SynthType::Union(u2)) => {
+            let all_variants = u1.variants.into_iter().chain(u2.variants);
+            SynthUnion::from_variants(all_variants)
+        }
+        (SynthType::Union(u), t) | (t, SynthType::Union(u)) => {
+            let all_variants = u.variants.into_iter().chain(std::iter::once(t));
+            SynthUnion::from_variants(all_variants)
+        }
+
+        // Arrays: unify element types
+        (SynthType::Array(a), SynthType::Array(b)) => SynthType::Array(Box::new(unify(*a, *b))),
+
+        // Tuples: unify element-wise if same length
+        (SynthType::Tuple(a), SynthType::Tuple(b)) if a.len() == b.len() => {
+            let unified: Vec<_> = a.into_iter().zip(b).map(|(x, y)| unify(x, y)).collect();
+            SynthType::Tuple(unified)
+        }
+
+        // Records: check if same shape for potential merging
+        (SynthType::Record(r1), SynthType::Record(r2)) => unify_records(r1, r2),
+
+        // Text with different languages
+        (SynthType::Text(l1), SynthType::Text(l2)) => {
+            // If either is implicit (None), prefer the explicit one
+            match (l1, l2) {
+                (None, l) | (l, None) => SynthType::Text(l),
+                (Some(a), Some(b)) if a == b => SynthType::Text(Some(a)),
+                (Some(a), Some(b)) => {
+                    // Different explicit languages form a union
+                    SynthUnion::from_variants([SynthType::Text(Some(a)), SynthType::Text(Some(b))])
+                }
+            }
+        }
+
+        // Different types: form a union
+        (t1, t2) => SynthUnion::from_variants([t1, t2]),
+    }
+}
+
+/// Unify two records.
+///
+/// Records with the same field names (regardless of types) are merged by
+/// unifying their field types. Records with different shapes form a union.
+///
+/// This design choice keeps record shapes distinct, which is useful for
+/// discriminated unions and type narrowing.
+fn unify_records(r1: SynthRecord, r2: SynthRecord) -> SynthType {
+    // Check if records have the same field names
+    let keys1: std::collections::HashSet<_> = r1.fields.keys().collect();
+    let keys2: std::collections::HashSet<_> = r2.fields.keys().collect();
+
+    if keys1 == keys2 {
+        // Same shape: merge by unifying field types
+        let mut fields = std::collections::HashMap::new();
+        for (name, f1) in r1.fields {
+            let f2 = r2.fields.get(&name).unwrap();
+            fields.insert(
+                name,
+                SynthField {
+                    ty: unify(f1.ty, f2.ty.clone()),
+                    optional: f1.optional || f2.optional,
+                },
+            );
+        }
+        SynthType::Record(SynthRecord { fields })
+    } else {
+        // Different shapes: form a union
+        SynthUnion::from_variants([SynthType::Record(r1), SynthType::Record(r2)])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unify_same() {
+        assert_eq!(
+            unify(SynthType::Integer, SynthType::Integer),
+            SynthType::Integer
+        );
+        assert_eq!(
+            unify(
+                SynthType::Text(Some("rust".into())),
+                SynthType::Text(Some("rust".into()))
+            ),
+            SynthType::Text(Some("rust".into()))
+        );
+    }
+
+    #[test]
+    fn test_unify_any() {
+        assert_eq!(
+            unify(SynthType::Any, SynthType::Integer),
+            SynthType::Integer
+        );
+        assert_eq!(
+            unify(SynthType::Integer, SynthType::Any),
+            SynthType::Integer
+        );
+    }
+
+    #[test]
+    fn test_unify_never() {
+        assert_eq!(
+            unify(SynthType::Never, SynthType::Integer),
+            SynthType::Integer
+        );
+        assert_eq!(
+            unify(SynthType::Integer, SynthType::Never),
+            SynthType::Integer
+        );
+    }
+
+    #[test]
+    fn test_unify_hole() {
+        assert_eq!(
+            unify(SynthType::Hole(None), SynthType::Integer),
+            SynthType::Integer
+        );
+        assert_eq!(
+            unify(SynthType::Integer, SynthType::Hole(None)),
+            SynthType::Integer
+        );
+    }
+
+    #[test]
+    fn test_unify_different_primitives() {
+        assert_eq!(
+            unify(SynthType::Integer, SynthType::Boolean),
+            SynthType::Union(SynthUnion {
+                variants: vec![SynthType::Integer, SynthType::Boolean]
+            })
+        );
+    }
+
+    #[test]
+    fn test_unify_arrays() {
+        let arr1 = SynthType::Array(Box::new(SynthType::Integer));
+        let arr2 = SynthType::Array(Box::new(SynthType::Boolean));
+        assert_eq!(
+            unify(arr1, arr2),
+            SynthType::Array(Box::new(SynthType::Union(SynthUnion {
+                variants: vec![SynthType::Integer, SynthType::Boolean]
+            })))
+        );
+    }
+
+    #[test]
+    fn test_unify_tuples_same_length() {
+        let t1 = SynthType::Tuple(vec![SynthType::Integer, SynthType::Boolean]);
+        let t2 = SynthType::Tuple(vec![SynthType::Integer, SynthType::Integer]);
+        assert_eq!(
+            unify(t1, t2),
+            SynthType::Tuple(vec![
+                SynthType::Integer,
+                SynthType::Union(SynthUnion {
+                    variants: vec![SynthType::Boolean, SynthType::Integer]
+                })
+            ])
+        );
+    }
+
+    #[test]
+    fn test_unify_tuples_different_length() {
+        let t1 = SynthType::Tuple(vec![SynthType::Integer]);
+        let t2 = SynthType::Tuple(vec![SynthType::Integer, SynthType::Boolean]);
+        assert_eq!(
+            unify(t1.clone(), t2.clone()),
+            SynthType::Union(SynthUnion {
+                variants: vec![t1, t2]
+            })
+        );
+    }
+
+    #[test]
+    fn test_unify_records_same_shape() {
+        let r1 = SynthRecord::new([
+            ("a".into(), SynthField::required(SynthType::Integer)),
+            ("b".into(), SynthField::required(SynthType::Boolean)),
+        ]);
+        let r2 = SynthRecord::new([
+            ("a".into(), SynthField::required(SynthType::Text(None))),
+            ("b".into(), SynthField::required(SynthType::Boolean)),
+        ]);
+
+        let expected = SynthType::Record(SynthRecord::new([
+            (
+                "a".into(),
+                SynthField::required(SynthType::Union(SynthUnion {
+                    variants: vec![SynthType::Integer, SynthType::Text(None)],
+                })),
+            ),
+            ("b".into(), SynthField::required(SynthType::Boolean)),
+        ]));
+        assert_eq!(
+            unify(SynthType::Record(r1), SynthType::Record(r2)),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_unify_records_different_shape() {
+        let r1 = SynthRecord::new([("a".into(), SynthField::required(SynthType::Integer))]);
+        let r2 = SynthRecord::new([
+            ("a".into(), SynthField::required(SynthType::Text(None))),
+            ("b".into(), SynthField::required(SynthType::Boolean)),
+        ]);
+
+        let expected = SynthType::Union(SynthUnion {
+            variants: vec![
+                SynthType::Record(SynthRecord::new([(
+                    "a".into(),
+                    SynthField::required(SynthType::Integer),
+                )])),
+                SynthType::Record(SynthRecord::new([
+                    ("a".into(), SynthField::required(SynthType::Text(None))),
+                    ("b".into(), SynthField::required(SynthType::Boolean)),
+                ])),
+            ],
+        });
+        assert_eq!(
+            unify(SynthType::Record(r1), SynthType::Record(r2)),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_unify_text_languages() {
+        // Implicit + explicit = explicit
+        assert_eq!(
+            unify(SynthType::Text(None), SynthType::Text(Some("rust".into()))),
+            SynthType::Text(Some("rust".into()))
+        );
+
+        // Same explicit = same
+        assert_eq!(
+            unify(
+                SynthType::Text(Some("rust".into())),
+                SynthType::Text(Some("rust".into()))
+            ),
+            SynthType::Text(Some("rust".into()))
+        );
+
+        // Different explicit = union
+        assert_eq!(
+            unify(
+                SynthType::Text(Some("rust".into())),
+                SynthType::Text(Some("python".into())),
+            ),
+            SynthType::Union(SynthUnion {
+                variants: vec![
+                    SynthType::Text(Some("rust".into())),
+                    SynthType::Text(Some("python".into()))
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn test_unify_unions() {
+        let u1 = SynthUnion::from_variants([SynthType::Integer, SynthType::Boolean]);
+        let u2 = SynthUnion::from_variants([SynthType::Text(None), SynthType::Float]);
+        assert_eq!(
+            unify(u1, u2),
+            SynthType::Union(SynthUnion {
+                variants: vec![
+                    SynthType::Integer,
+                    SynthType::Boolean,
+                    SynthType::Text(None),
+                    SynthType::Float
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn test_unify_union_with_member() {
+        let union = SynthUnion::from_variants([SynthType::Integer, SynthType::Boolean]);
+        assert_eq!(
+            unify(union, SynthType::Text(None)),
+            SynthType::Union(SynthUnion {
+                variants: vec![
+                    SynthType::Integer,
+                    SynthType::Boolean,
+                    SynthType::Text(None)
+                ]
+            })
+        );
+    }
+}


### PR DESCRIPTION
Introduces a new synth module in eure-schema that synthesizes types from EureDocument values without requiring a schema. Key features:

- SynthType enum: Null, Boolean, Integer, Float, Text (with language), Array, Tuple, Record, Union, Any, Never, Hole
- Structural unions (not tagged) for heterogeneous collections
- Type unification algorithm:
  - Same-shape records merge by unifying field types
  - Different-shape records form unions
  - Holes are absorbed (e.g., [1, !, 3] → Array<Integer>)
  - Text language coercion (implicit → explicit)

Design decisions:
- Union of records over field merging for precision
- No extension typing (extensions aren't part of data model)
- Text carries optional language info