### PR TITLE
Redesign eure-fmt architecture from scratch

### DIFF
--- a/crates/eure-fmt/src/builder.rs
+++ b/crates/eure-fmt/src/builder.rs
@@ -1,0 +1,966 @@
+//! CST to Doc IR builder using CstVisitor.
+//!
+//! This module converts the concrete syntax tree into the Doc intermediate
+//! representation for formatting, using the CstVisitor pattern to properly
+//! handle trivia (comments, whitespace, newlines).
+
+use std::convert::Infallible;
+
+use eure_tree::prelude::*;
+use eure_tree::tree::{LineNumbers, TerminalData};
+
+use crate::config::FormatConfig;
+use crate::doc::Doc;
+
+/// Builder that converts CST to Doc IR using CstVisitor.
+pub struct FormatBuilder<'a> {
+    input: &'a str,
+    config: &'a FormatConfig,
+    line_numbers: LineNumbers<'a>,
+}
+
+impl<'a> FormatBuilder<'a> {
+    /// Create a new format builder.
+    pub fn new(input: &'a str, _tree: &'a Cst, config: &'a FormatConfig) -> Self {
+        Self {
+            input,
+            config,
+            line_numbers: LineNumbers::new(input),
+        }
+    }
+
+    /// Build the Doc IR from the CST.
+    pub fn build(&self, tree: &Cst) -> Doc {
+        let mut visitor = FormatVisitor::new(self.input, self.config, &self.line_numbers);
+        let _ = tree.visit_from_root(&mut visitor);
+        visitor.finish()
+    }
+}
+
+/// Visitor state for building Doc IR.
+struct FormatVisitor<'a> {
+    input: &'a str,
+    config: &'a FormatConfig,
+    line_numbers: &'a LineNumbers<'a>,
+    /// Stack of document fragments being built
+    docs: Vec<Doc>,
+    /// Track if we've seen a newline since last content (for comment classification)
+    seen_newline: bool,
+    /// Track position of last content for trailing comment detection
+    last_content_end: Option<u32>,
+    /// Track if we're at the start (no content output yet)
+    at_start: bool,
+    /// Track if we just added a hardline (to avoid duplicates)
+    pending_newline: bool,
+    /// Context stack for nested structures (array, object, etc.)
+    context: Vec<FormatContext>,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum FormatContext {
+    Root,
+    Eure,
+    Binding,
+    ValueBinding,
+    Object,
+    Array,
+    Tuple,
+    Section,
+    Keys,
+    CodeBlock,
+    Text,
+}
+
+impl<'a> FormatVisitor<'a> {
+    fn new(input: &'a str, config: &'a FormatConfig, line_numbers: &'a LineNumbers<'a>) -> Self {
+        Self {
+            input,
+            config,
+            line_numbers,
+            docs: Vec::new(),
+            seen_newline: true, // Start as if we're on a new line
+            last_content_end: None,
+            at_start: true,
+            pending_newline: false,
+            context: vec![FormatContext::Root],
+        }
+    }
+
+    fn finish(mut self) -> Doc {
+        // Ensure file ends with newline
+        if !self.docs.is_empty() {
+            self.docs.push(Doc::hardline());
+        }
+        Doc::concat_all(self.docs)
+    }
+
+    fn current_context(&self) -> FormatContext {
+        self.context.last().copied().unwrap_or(FormatContext::Root)
+    }
+
+    fn push_context(&mut self, ctx: FormatContext) {
+        self.context.push(ctx);
+    }
+
+    fn pop_context(&mut self) {
+        self.context.pop();
+    }
+
+    fn get_text(&self, data: TerminalData) -> String {
+        match data {
+            TerminalData::Input(span) => {
+                self.input[span.start as usize..span.end as usize].to_string()
+            }
+            TerminalData::Dynamic(_) => {
+                // Dynamic tokens shouldn't occur in formatted output
+                String::new()
+            }
+        }
+    }
+
+    /// Emit the text of a terminal directly
+    fn emit_terminal(&mut self, data: TerminalData) {
+        let text = self.get_text(data);
+        if !text.is_empty() {
+            self.flush_newline();
+            self.docs.push(Doc::text(text));
+            self.at_start = false;
+        }
+        self.mark_content(data);
+    }
+
+    fn get_span_end(&self, data: TerminalData) -> Option<u32> {
+        match data {
+            TerminalData::Input(span) => Some(span.end),
+            _ => None,
+        }
+    }
+
+    fn get_span_start(&self, data: TerminalData) -> Option<u32> {
+        match data {
+            TerminalData::Input(span) => Some(span.start),
+            _ => None,
+        }
+    }
+
+    fn same_line(&self, pos1: u32, pos2: u32) -> bool {
+        self.line_numbers.get_char_info(pos1).line_number
+            == self.line_numbers.get_char_info(pos2).line_number
+    }
+
+    /// Request a newline before the next content (deferred to avoid duplicates)
+    fn request_newline(&mut self) {
+        if !self.at_start {
+            self.pending_newline = true;
+        }
+    }
+
+    /// Flush any pending newline before emitting content
+    fn flush_newline(&mut self) {
+        if self.pending_newline {
+            self.docs.push(Doc::hardline());
+            self.pending_newline = false;
+        }
+    }
+
+    /// Output a document fragment
+    fn emit(&mut self, doc: Doc) {
+        if !matches!(doc, Doc::Nil) {
+            self.flush_newline();
+            self.docs.push(doc);
+            self.at_start = false;
+        }
+    }
+
+    /// Output text
+    fn emit_text(&mut self, text: impl Into<String>) {
+        let text: String = text.into();
+        if !text.is_empty() {
+            self.flush_newline();
+            self.docs.push(Doc::text(text));
+            self.at_start = false;
+        }
+    }
+
+    /// Handle a block comment terminal
+    fn handle_comment(&mut self, data: TerminalData) {
+        let text = self.get_text(data);
+        let span_start = self.get_span_start(data);
+        let span_end = self.get_span_end(data);
+
+        // Check if this is a trailing comment (same line as previous content)
+        let is_trailing = match (self.last_content_end, span_start) {
+            (Some(prev_end), Some(start)) => self.same_line(prev_end, start),
+            _ => false,
+        };
+
+        if is_trailing {
+            // Trailing comment: space before, no newline after
+            self.docs.push(Doc::text(" "));
+            self.emit_text(text);
+        } else {
+            // Standalone comment: use emit_text to flush pending newline,
+            // then request newline after for the next content
+            self.emit_text(text);
+            self.request_newline();
+        }
+
+        // Mark that we've seen content (for next item)
+        self.last_content_end = span_end;
+        self.seen_newline = false;
+    }
+
+    /// Mark that content was output at a position
+    fn mark_content(&mut self, data: TerminalData) {
+        self.last_content_end = self.get_span_end(data);
+        self.seen_newline = false;
+        self.at_start = false;
+    }
+}
+
+impl<F: CstFacade> CstVisitor<F> for FormatVisitor<'_> {
+    type Error = Infallible;
+
+    // === Trivia handling ===
+
+    fn visit_new_line_terminal(
+        &mut self,
+        _terminal: NewLine,
+        _data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        self.seen_newline = true;
+        Ok(())
+    }
+
+    fn visit_whitespace_terminal(
+        &mut self,
+        _terminal: Whitespace,
+        _data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        // Skip whitespace - we add our own formatting
+        Ok(())
+    }
+
+    fn visit_line_comment_terminal(
+        &mut self,
+        _terminal: LineComment,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        // Line comments include their trailing newline, which we need to handle specially
+        let text = self.get_text(data);
+        let span_start = self.get_span_start(data);
+        let span_end = self.get_span_end(data);
+
+        // Strip trailing newline from comment text (we handle newlines via Doc)
+        let text = text.trim_end_matches(['\n', '\r']);
+
+        // Check if this is a trailing comment (same line as previous content)
+        let is_trailing = match (self.last_content_end, span_start) {
+            (Some(prev_end), Some(start)) => self.same_line(prev_end, start),
+            _ => false,
+        };
+
+        if is_trailing {
+            // Trailing comment: space before, request newline after (for next content)
+            self.docs.push(Doc::text(" "));
+            self.emit_text(text);
+            self.request_newline();
+        } else {
+            // Standalone comment: emit_text flushes pending newline,
+            // then request newline after for the next content
+            self.emit_text(text);
+            self.request_newline();
+        }
+
+        self.last_content_end = span_end;
+        self.seen_newline = true; // Line comment ends with newline semantically
+        Ok(())
+    }
+
+    fn visit_block_comment_terminal(
+        &mut self,
+        _terminal: BlockComment,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        self.handle_comment(data);
+        Ok(())
+    }
+
+    // === Structure handling ===
+
+    fn visit_eure(
+        &mut self,
+        handle: EureHandle,
+        view: EureView,
+        tree: &F,
+    ) -> Result<(), Self::Error> {
+        self.push_context(FormatContext::Eure);
+        self.visit_eure_super(handle, view, tree)?;
+        self.pop_context();
+        Ok(())
+    }
+
+    fn visit_binding(
+        &mut self,
+        handle: BindingHandle,
+        view: BindingView,
+        tree: &F,
+    ) -> Result<(), Self::Error> {
+        // Request newline before binding - will be flushed when first content is emitted
+        // This allows trivia (comments) to be processed first and manage their own newlines
+        self.request_newline();
+        self.push_context(FormatContext::Binding);
+        self.visit_binding_super(handle, view, tree)?;
+        self.pop_context();
+        Ok(())
+    }
+
+    fn visit_value_binding(
+        &mut self,
+        handle: ValueBindingHandle,
+        view: ValueBindingView,
+        tree: &F,
+    ) -> Result<(), Self::Error> {
+        self.push_context(FormatContext::ValueBinding);
+        self.visit_value_binding_super(handle, view, tree)?;
+        self.pop_context();
+        Ok(())
+    }
+
+    fn visit_section(
+        &mut self,
+        handle: SectionHandle,
+        view: SectionView,
+        tree: &F,
+    ) -> Result<(), Self::Error> {
+        // Request newline before section - will be flushed when first content is emitted
+        self.request_newline();
+        self.push_context(FormatContext::Section);
+        self.visit_section_super(handle, view, tree)?;
+        self.pop_context();
+        Ok(())
+    }
+
+    fn visit_keys(
+        &mut self,
+        handle: KeysHandle,
+        view: KeysView,
+        tree: &F,
+    ) -> Result<(), Self::Error> {
+        self.push_context(FormatContext::Keys);
+        self.visit_keys_super(handle, view, tree)?;
+        self.pop_context();
+        Ok(())
+    }
+
+    // === Terminal handling ===
+
+    fn visit_bind_terminal(
+        &mut self,
+        _terminal: Bind,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        // Only add space before = if there's content before it (i.e., a key)
+        if self.at_start {
+            self.emit_text("= ");
+        } else {
+            self.emit_text(" = ");
+        }
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_at_terminal(
+        &mut self,
+        _terminal: At,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        self.emit_text("@ ");
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_dot_terminal(
+        &mut self,
+        _terminal: Dot,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        self.emit_text(".");
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_l_brace_terminal(
+        &mut self,
+        _terminal: LBrace,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        self.emit_text("{");
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_r_brace_terminal(
+        &mut self,
+        _terminal: RBrace,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        self.emit_text("}");
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_l_bracket_terminal(
+        &mut self,
+        _terminal: LBracket,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        self.emit_text("[");
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_r_bracket_terminal(
+        &mut self,
+        _terminal: RBracket,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        self.emit_text("]");
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_l_paren_terminal(
+        &mut self,
+        _terminal: LParen,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        self.emit_text("(");
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_r_paren_terminal(
+        &mut self,
+        _terminal: RParen,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        self.emit_text(")");
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_comma_terminal(
+        &mut self,
+        _terminal: Comma,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        self.emit_text(", ");
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_map_bind_terminal(
+        &mut self,
+        _terminal: MapBind,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        self.emit_text(" => ");
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_ident_terminal(
+        &mut self,
+        _terminal: Ident,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        self.emit_terminal(data);
+        Ok(())
+    }
+
+    fn visit_integer_terminal(
+        &mut self,
+        _terminal: Integer,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        self.emit_terminal(data);
+        Ok(())
+    }
+
+    fn visit_float_terminal(
+        &mut self,
+        _terminal: Float,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        self.emit_terminal(data);
+        Ok(())
+    }
+
+    fn visit_true_terminal(
+        &mut self,
+        _terminal: True,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        self.emit_text("true");
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_false_terminal(
+        &mut self,
+        _terminal: False,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        self.emit_text("false");
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_null_terminal(
+        &mut self,
+        _terminal: Null,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        self.emit_text("null");
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_hole_terminal(
+        &mut self,
+        _terminal: Hole,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        self.emit_terminal(data);
+        Ok(())
+    }
+
+    fn visit_str_terminal(
+        &mut self,
+        _terminal: Str,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        self.emit_terminal(data);
+        Ok(())
+    }
+
+    fn visit_hash_terminal(
+        &mut self,
+        _terminal: Hash,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        self.emit_text("#");
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_esc_terminal(
+        &mut self,
+        _terminal: Esc,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        self.emit_text(" \\");
+        self.emit(Doc::hardline());
+        self.mark_content(data);
+        Ok(())
+    }
+
+    // Code blocks - preserve verbatim
+    fn visit_code_block_start_3_terminal(
+        &mut self,
+        _terminal: CodeBlockStart3,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        let text = self.get_text(data);
+        self.emit_text(text);
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_code_block_start_4_terminal(
+        &mut self,
+        _terminal: CodeBlockStart4,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        let text = self.get_text(data);
+        self.emit_text(text);
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_code_block_start_5_terminal(
+        &mut self,
+        _terminal: CodeBlockStart5,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        let text = self.get_text(data);
+        self.emit_text(text);
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_code_block_start_6_terminal(
+        &mut self,
+        _terminal: CodeBlockStart6,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        let text = self.get_text(data);
+        self.emit_text(text);
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_code_block_end_3_terminal(
+        &mut self,
+        _terminal: CodeBlockEnd3,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        let text = self.get_text(data);
+        self.emit_text(text);
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_code_block_end_4_terminal(
+        &mut self,
+        _terminal: CodeBlockEnd4,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        let text = self.get_text(data);
+        self.emit_text(text);
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_code_block_end_5_terminal(
+        &mut self,
+        _terminal: CodeBlockEnd5,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        let text = self.get_text(data);
+        self.emit_text(text);
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_code_block_end_6_terminal(
+        &mut self,
+        _terminal: CodeBlockEnd6,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        let text = self.get_text(data);
+        self.emit_text(text);
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_no_backtick_terminal(
+        &mut self,
+        _terminal: NoBacktick,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        let text = self.get_text(data);
+        self.emit_text(text);
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_backtick_2_terminal(
+        &mut self,
+        _terminal: Backtick2,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        let text = self.get_text(data);
+        self.emit_text(text);
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_backtick_3_terminal(
+        &mut self,
+        _terminal: Backtick3,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        let text = self.get_text(data);
+        self.emit_text(text);
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_backtick_4_terminal(
+        &mut self,
+        _terminal: Backtick4,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        let text = self.get_text(data);
+        self.emit_text(text);
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_backtick_5_terminal(
+        &mut self,
+        _terminal: Backtick5,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        let text = self.get_text(data);
+        self.emit_text(text);
+        self.mark_content(data);
+        Ok(())
+    }
+
+    // Inline code
+    fn visit_inline_code_1_terminal(
+        &mut self,
+        _terminal: InlineCode1,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        let text = self.get_text(data);
+        self.emit_text(text);
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_inline_code_start_2_terminal(
+        &mut self,
+        _terminal: InlineCodeStart2,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        let text = self.get_text(data);
+        self.emit_text(text);
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_inline_code_end_2_terminal(
+        &mut self,
+        _terminal: InlineCodeEnd2,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        let text = self.get_text(data);
+        self.emit_text(text);
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_no_backtick_inline_terminal(
+        &mut self,
+        _terminal: NoBacktickInline,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        let text = self.get_text(data);
+        self.emit_text(text);
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_backtick_1_terminal(
+        &mut self,
+        _terminal: Backtick1,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        let text = self.get_text(data);
+        self.emit_text(text);
+        self.mark_content(data);
+        Ok(())
+    }
+
+    // Text binding
+    fn visit_text_start_terminal(
+        &mut self,
+        _terminal: TextStart,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        self.emit_text(":");
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_text_terminal(
+        &mut self,
+        _terminal: Text,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        let text = self.get_text(data);
+        self.emit_text(text);
+        self.mark_content(data);
+        Ok(())
+    }
+
+    fn visit_grammar_newline_terminal(
+        &mut self,
+        _terminal: GrammarNewline,
+        _data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        // This appears in text bindings, output as newline
+        self.emit(Doc::hardline());
+        self.seen_newline = true;
+        Ok(())
+    }
+
+    fn visit_ws_terminal(
+        &mut self,
+        _terminal: Ws,
+        data: TerminalData,
+        _tree: &F,
+    ) -> Result<(), Self::Error> {
+        // Whitespace in text contexts - preserve it
+        let text = self.get_text(data);
+        self.emit_text(text);
+        self.mark_content(data);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn format(input: &str) -> String {
+        format_width(input, 100)
+    }
+
+    fn format_width(input: &str, width: usize) -> String {
+        let cst = eure_parol::parse(input).expect("parse failed");
+        let config = FormatConfig::default().with_max_width(width);
+        let builder = FormatBuilder::new(input, &cst, &config);
+        let doc = builder.build(&cst);
+        crate::printer::Printer::new(config).print(&doc)
+    }
+
+    #[test]
+    fn test_simple_binding() {
+        let input = "a = 1";
+        let output = format(input);
+        assert_eq!(output, "a = 1\n");
+    }
+
+    #[test]
+    fn test_nested_binding() {
+        let input = "a.b = 1";
+        let output = format(input);
+        assert_eq!(output, "a.b = 1\n");
+    }
+
+    #[test]
+    fn test_array_binding() {
+        let input = "= [1, 2, 3]";
+        let output = format(input);
+        assert_eq!(output, "= [1, 2, 3]\n");
+    }
+
+    #[test]
+    fn test_object_binding() {
+        let input = "= { b => 1 }";
+        let output = format(input);
+        assert_eq!(output, "= {b => 1}\n");
+    }
+
+    #[test]
+    fn test_section() {
+        let input = "@ foo\na = 1";
+        let output = format(input);
+        assert_eq!(output, "@ foo\na = 1\n");
+    }
+
+    #[test]
+    fn test_empty_array() {
+        let input = "= []";
+        let output = format(input);
+        assert_eq!(output, "= []\n");
+    }
+
+    #[test]
+    fn test_empty_object() {
+        let input = "= {}";
+        let output = format(input);
+        assert_eq!(output, "= {}\n");
+    }
+
+    #[test]
+    fn test_object_inline_with_commas() {
+        // Multiple object entries should have commas when inline
+        let input = "= { a => 1, b => 2 }";
+        let output = format(input);
+        assert_eq!(output, "= {a => 1, b => 2}\n");
+    }
+
+    #[test]
+    fn test_line_comment_standalone() {
+        // Line comments on their own line should be preserved
+        let input = "// this is a comment\na = 1";
+        let output = format(input);
+        assert_eq!(output, "// this is a comment\na = 1\n");
+    }
+
+    #[test]
+    fn test_line_comment_trailing() {
+        // Trailing comments should stay on the same line as the value
+        let input = "a = 1 // trailing comment";
+        let output = format(input);
+        assert_eq!(output, "a = 1 // trailing comment\n");
+    }
+
+    #[test]
+    fn test_block_comment() {
+        // Block comments on their own line should be followed by newline
+        let input = "/* block comment */\na = 1";
+        let output = format(input);
+        assert_eq!(output, "/* block comment */\na = 1\n");
+    }
+
+    #[test]
+    fn test_comment_between_bindings() {
+        // Comments between bindings should have proper newlines
+        let input = "a = 1\n// comment\nb = 2";
+        let output = format(input);
+        assert_eq!(output, "a = 1\n// comment\nb = 2\n");
+    }
+}

--- a/crates/eure-fmt/src/builder.rs
+++ b/crates/eure-fmt/src/builder.rs
@@ -15,6 +15,7 @@ use crate::doc::Doc;
 /// Builder that converts CST to Doc IR using CstVisitor.
 pub struct FormatBuilder<'a> {
     input: &'a str,
+    #[allow(dead_code)] // Will be used for configurable indent, etc.
     config: &'a FormatConfig,
     line_numbers: LineNumbers<'a>,
 }
@@ -31,7 +32,7 @@ impl<'a> FormatBuilder<'a> {
 
     /// Build the Doc IR from the CST.
     pub fn build(&self, tree: &Cst) -> Doc {
-        let mut visitor = FormatVisitor::new(self.input, self.config, &self.line_numbers);
+        let mut visitor = FormatVisitor::new(self.input, &self.line_numbers);
         let _ = tree.visit_from_root(&mut visitor);
         visitor.finish()
     }
@@ -40,7 +41,6 @@ impl<'a> FormatBuilder<'a> {
 /// Visitor state for building Doc IR.
 struct FormatVisitor<'a> {
     input: &'a str,
-    config: &'a FormatConfig,
     line_numbers: &'a LineNumbers<'a>,
     /// Stack of document fragments being built
     docs: Vec<Doc>,
@@ -71,19 +71,14 @@ enum FormatContext {
     SectionBinding,
     SectionBody,
     Object,
-    Array,
-    Tuple,
     Section,
     Keys,
-    CodeBlock,
-    Text,
 }
 
 impl<'a> FormatVisitor<'a> {
-    fn new(input: &'a str, config: &'a FormatConfig, line_numbers: &'a LineNumbers<'a>) -> Self {
+    fn new(input: &'a str, line_numbers: &'a LineNumbers<'a>) -> Self {
         Self {
             input,
-            config,
             line_numbers,
             docs: Vec::new(),
             seen_newline: true, // Start as if we're on a new line

--- a/crates/eure-fmt/src/config.rs
+++ b/crates/eure-fmt/src/config.rs
@@ -1,0 +1,104 @@
+//! Formatter configuration.
+
+/// Configuration options for the Eure formatter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FormatConfig {
+    /// Maximum line width (guideline, not strict limit).
+    /// Default: 100
+    pub max_width: usize,
+
+    /// Number of spaces per indentation level.
+    /// Default: 2
+    pub indent_width: usize,
+
+    /// Use tabs instead of spaces for indentation.
+    /// Default: false
+    pub use_tabs: bool,
+
+    /// Trailing comma policy for multiline arrays/objects.
+    /// Default: TrailingComma::Always
+    pub trailing_comma: TrailingComma,
+
+    /// Newline style.
+    /// Default: NewlineStyle::Lf
+    pub newline: NewlineStyle,
+}
+
+impl Default for FormatConfig {
+    fn default() -> Self {
+        Self {
+            max_width: 100,
+            indent_width: 2,
+            use_tabs: false,
+            trailing_comma: TrailingComma::Always,
+            newline: NewlineStyle::Lf,
+        }
+    }
+}
+
+impl FormatConfig {
+    /// Create a new config with default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set max width.
+    pub fn with_max_width(mut self, width: usize) -> Self {
+        self.max_width = width;
+        self
+    }
+
+    /// Set indent width.
+    pub fn with_indent_width(mut self, width: usize) -> Self {
+        self.indent_width = width;
+        self
+    }
+
+    /// Set tab usage.
+    pub fn with_tabs(mut self, use_tabs: bool) -> Self {
+        self.use_tabs = use_tabs;
+        self
+    }
+
+    /// Set trailing comma policy.
+    pub fn with_trailing_comma(mut self, policy: TrailingComma) -> Self {
+        self.trailing_comma = policy;
+        self
+    }
+
+    /// Set newline style.
+    pub fn with_newline(mut self, style: NewlineStyle) -> Self {
+        self.newline = style;
+        self
+    }
+}
+
+/// Trailing comma policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TrailingComma {
+    /// Always add trailing commas in multiline contexts.
+    #[default]
+    Always,
+    /// Never add trailing commas.
+    Never,
+}
+
+/// Newline style.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum NewlineStyle {
+    /// Unix-style line endings (LF).
+    #[default]
+    Lf,
+    /// Windows-style line endings (CRLF).
+    Crlf,
+}
+
+impl NewlineStyle {
+    /// Get the newline string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            NewlineStyle::Lf => "\n",
+            NewlineStyle::Crlf => "\r\n",
+        }
+    }
+}

--- a/crates/eure-fmt/src/doc.rs
+++ b/crates/eure-fmt/src/doc.rs
@@ -1,0 +1,230 @@
+//! Document IR for the Eure formatter.
+//!
+//! This module defines the intermediate representation used by the formatter.
+//! The design follows Wadler's "A Prettier Printer" algorithm.
+
+/// Intermediate representation for formatting.
+///
+/// A `Doc` describes how content should be laid out, with the actual
+/// line-breaking decisions deferred to the printer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Doc {
+    /// Empty document
+    Nil,
+
+    /// Literal text (no line breaks allowed within)
+    Text(String),
+
+    /// A line break: becomes a single space if the enclosing group fits on one line,
+    /// otherwise becomes a newline followed by current indentation.
+    Line,
+
+    /// A soft line break: becomes empty if the enclosing group fits on one line,
+    /// otherwise becomes a newline followed by current indentation.
+    SoftLine,
+
+    /// Always a line break, regardless of whether the group fits.
+    HardLine,
+
+    /// Increase indentation for the nested document.
+    Indent(Box<Doc>),
+
+    /// Concatenate two documents.
+    Concat(Box<Doc>, Box<Doc>),
+
+    /// Try to fit the document on one line. If it doesn't fit within the
+    /// max width, break at `Line` and `SoftLine` positions.
+    Group(Box<Doc>),
+
+    /// Conditional content based on whether the enclosing group breaks.
+    /// - `flat`: used when the group fits on one line
+    /// - `broken`: used when the group breaks across lines
+    IfBreak { flat: Box<Doc>, broken: Box<Doc> },
+}
+
+impl Doc {
+    /// Create a text document.
+    pub fn text(s: impl Into<String>) -> Doc {
+        let s = s.into();
+        if s.is_empty() { Doc::Nil } else { Doc::Text(s) }
+    }
+
+    /// Create a line break (space when flat, newline when broken).
+    pub fn line() -> Doc {
+        Doc::Line
+    }
+
+    /// Create a soft line break (empty when flat, newline when broken).
+    pub fn softline() -> Doc {
+        Doc::SoftLine
+    }
+
+    /// Create a hard line break (always a newline).
+    pub fn hardline() -> Doc {
+        Doc::HardLine
+    }
+
+    /// Indent the given document.
+    pub fn indent(doc: Doc) -> Doc {
+        if matches!(doc, Doc::Nil) {
+            Doc::Nil
+        } else {
+            Doc::Indent(Box::new(doc))
+        }
+    }
+
+    /// Create a group that tries to fit on one line.
+    pub fn group(doc: Doc) -> Doc {
+        if matches!(doc, Doc::Nil) {
+            Doc::Nil
+        } else {
+            Doc::Group(Box::new(doc))
+        }
+    }
+
+    /// Concatenate two documents.
+    pub fn concat(self, other: Doc) -> Doc {
+        match (self, other) {
+            (Doc::Nil, other) => other,
+            (this, Doc::Nil) => this,
+            (this, other) => Doc::Concat(Box::new(this), Box::new(other)),
+        }
+    }
+
+    /// Conditional content based on break state.
+    pub fn if_break(flat: Doc, broken: Doc) -> Doc {
+        Doc::IfBreak {
+            flat: Box::new(flat),
+            broken: Box::new(broken),
+        }
+    }
+
+    /// Join multiple documents with a separator.
+    pub fn join(docs: impl IntoIterator<Item = Doc>, sep: Doc) -> Doc {
+        let mut result = Doc::Nil;
+        let mut first = true;
+        for doc in docs {
+            if first {
+                first = false;
+                result = doc;
+            } else {
+                result = result.concat(sep.clone()).concat(doc);
+            }
+        }
+        result
+    }
+
+    /// Concatenate multiple documents.
+    pub fn concat_all(docs: impl IntoIterator<Item = Doc>) -> Doc {
+        let mut result = Doc::Nil;
+        for doc in docs {
+            result = result.concat(doc);
+        }
+        result
+    }
+
+    /// Wrap content with prefix and suffix.
+    pub fn surround(prefix: Doc, content: Doc, suffix: Doc) -> Doc {
+        prefix.concat(content).concat(suffix)
+    }
+}
+
+/// Builder for constructing documents fluently.
+#[derive(Debug, Default)]
+pub struct DocBuilder {
+    parts: Vec<Doc>,
+}
+
+impl DocBuilder {
+    /// Create a new empty builder.
+    pub fn new() -> Self {
+        Self { parts: Vec::new() }
+    }
+
+    /// Add text.
+    pub fn text(&mut self, s: impl Into<String>) -> &mut Self {
+        self.parts.push(Doc::text(s));
+        self
+    }
+
+    /// Add a line break.
+    pub fn line(&mut self) -> &mut Self {
+        self.parts.push(Doc::line());
+        self
+    }
+
+    /// Add a soft line break.
+    pub fn softline(&mut self) -> &mut Self {
+        self.parts.push(Doc::softline());
+        self
+    }
+
+    /// Add a hard line break.
+    pub fn hardline(&mut self) -> &mut Self {
+        self.parts.push(Doc::hardline());
+        self
+    }
+
+    /// Add a document.
+    pub fn push(&mut self, doc: Doc) -> &mut Self {
+        self.parts.push(doc);
+        self
+    }
+
+    /// Build the final document.
+    pub fn build(self) -> Doc {
+        Doc::concat_all(self.parts)
+    }
+
+    /// Build as a group.
+    pub fn build_group(self) -> Doc {
+        Doc::group(self.build())
+    }
+
+    /// Build with indentation.
+    pub fn build_indent(self) -> Doc {
+        Doc::indent(self.build())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_text_empty() {
+        assert_eq!(Doc::text(""), Doc::Nil);
+    }
+
+    #[test]
+    fn test_text_non_empty() {
+        assert_eq!(Doc::text("hello"), Doc::Text("hello".to_string()));
+    }
+
+    #[test]
+    fn test_concat_nil() {
+        let doc = Doc::text("a").concat(Doc::Nil);
+        assert_eq!(doc, Doc::Text("a".to_string()));
+
+        let doc = Doc::Nil.concat(Doc::text("b"));
+        assert_eq!(doc, Doc::Text("b".to_string()));
+    }
+
+    #[test]
+    fn test_join() {
+        let docs = vec![Doc::text("a"), Doc::text("b"), Doc::text("c")];
+        let joined = Doc::join(docs, Doc::text(", "));
+        // Should produce: a, b, c (as nested concats)
+        assert!(matches!(joined, Doc::Concat(_, _)));
+    }
+
+    #[test]
+    fn test_builder() {
+        let doc = {
+            let mut b = DocBuilder::new();
+            b.text("hello").line().text("world");
+            b.build()
+        };
+        assert!(matches!(doc, Doc::Concat(_, _)));
+    }
+}

--- a/crates/eure-fmt/src/lib.rs
+++ b/crates/eure-fmt/src/lib.rs
@@ -1,2 +1,191 @@
+//! Eure formatter.
+//!
+//! This crate provides formatting functionality for Eure files, using an
+//! IR-based architecture inspired by Wadler's "A Prettier Printer" algorithm.
+//!
+//! # Architecture
+//!
+//! The formatter uses a three-stage pipeline:
+//!
+//! 1. **Parse** - Source text → CST (done externally via `eure-parol`)
+//! 2. **Build** - CST → Doc IR (intermediate representation)
+//! 3. **Print** - Doc IR → Formatted string
+//!
+//! # Example
+//!
+//! ```ignore
+//! use eure_fmt::{format, FormatConfig};
+//!
+//! let input = "a={b=1,c=2}";
+//! let config = FormatConfig::default();
+//! let formatted = format(input, &config).unwrap();
+//! ```
+
+mod builder;
+pub mod config;
+pub mod doc;
+pub mod printer;
+
 #[cfg(any(feature = "unformat", test))]
 pub mod unformat;
+
+pub use config::FormatConfig;
+pub use doc::Doc;
+
+use eure_tree::Cst;
+
+use builder::FormatBuilder;
+use printer::Printer;
+
+/// Error that can occur during formatting.
+#[derive(Debug, Clone)]
+pub enum FormatError {
+    /// Failed to parse the input.
+    ParseError(String),
+}
+
+impl std::fmt::Display for FormatError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FormatError::ParseError(msg) => write!(f, "Parse error: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for FormatError {}
+
+/// Result of checking if a file is formatted.
+#[derive(Debug, Clone)]
+pub enum FormatCheckResult {
+    /// The input is already well-formatted.
+    WellFormatted,
+    /// The input needs formatting.
+    NeedsFormatting {
+        /// The formatted output.
+        formatted: String,
+    },
+    /// Failed to parse the input.
+    ParseError(String),
+}
+
+impl FormatCheckResult {
+    /// Returns true if the input is well-formatted.
+    pub fn is_well_formatted(&self) -> bool {
+        matches!(self, FormatCheckResult::WellFormatted)
+    }
+
+    /// Returns true if the input needs formatting.
+    pub fn needs_formatting(&self) -> bool {
+        matches!(self, FormatCheckResult::NeedsFormatting { .. })
+    }
+
+    /// Returns true if there was a parse error.
+    pub fn is_parse_error(&self) -> bool {
+        matches!(self, FormatCheckResult::ParseError(_))
+    }
+}
+
+/// Format Eure source code using an already-parsed CST.
+///
+/// This is the lower-level API that works directly with the CST.
+pub fn format_cst(input: &str, cst: &Cst, config: &FormatConfig) -> String {
+    let builder = FormatBuilder::new(input, cst, config);
+    let doc = builder.build(cst);
+    Printer::new(config.clone()).print(&doc)
+}
+
+/// Build a Doc IR from a CST.
+///
+/// This is useful for debugging or custom printing.
+pub fn build_doc(input: &str, cst: &Cst, config: &FormatConfig) -> Doc {
+    let builder = FormatBuilder::new(input, cst, config);
+    builder.build(cst)
+}
+
+/// A text edit representing a change to apply.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TextEdit {
+    /// Start offset in bytes.
+    pub start: usize,
+    /// End offset in bytes.
+    pub end: usize,
+    /// New text to insert.
+    pub new_text: String,
+}
+
+/// Compute text edits to transform input into formatted output.
+///
+/// This is useful for LSP integration where you need incremental edits
+/// rather than full file replacement.
+pub fn compute_edits(input: &str, formatted: &str) -> Vec<TextEdit> {
+    // For now, use a simple full-file replacement
+    // A more sophisticated implementation would use a diff algorithm
+    if input == formatted {
+        Vec::new()
+    } else {
+        vec![TextEdit {
+            start: 0,
+            end: input.len(),
+            new_text: formatted.to_string(),
+        }]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_and_format(input: &str) -> String {
+        let cst = eure_parol::parse(input).expect("parse failed");
+        format_cst(input, &cst, &FormatConfig::default())
+    }
+
+    #[test]
+    fn test_format_simple() {
+        let formatted = parse_and_format("a = 1");
+        assert_eq!(formatted, "a = 1\n");
+    }
+
+    #[test]
+    fn test_format_preserves_content() {
+        let input = "name = \"hello\"\nage = 42";
+        let formatted = parse_and_format(input);
+        assert!(formatted.contains("name"));
+        assert!(formatted.contains("\"hello\""));
+        assert!(formatted.contains("age"));
+        assert!(formatted.contains("42"));
+    }
+
+    #[test]
+    fn test_format_array() {
+        let formatted = parse_and_format("= [1, 2, 3]");
+        assert_eq!(formatted, "= [1, 2, 3]\n");
+    }
+
+    #[test]
+    fn test_format_empty_array() {
+        let formatted = parse_and_format("= []");
+        assert_eq!(formatted, "= []\n");
+    }
+
+    #[test]
+    fn test_format_empty_object() {
+        let formatted = parse_and_format("= {}");
+        assert_eq!(formatted, "= {}\n");
+    }
+
+    #[test]
+    fn test_compute_edits_no_change() {
+        let edits = compute_edits("a = 1\n", "a = 1\n");
+        assert!(edits.is_empty());
+    }
+
+    #[test]
+    fn test_compute_edits_with_change() {
+        let edits = compute_edits("a=1", "a = 1\n");
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].start, 0);
+        assert_eq!(edits[0].end, 3);
+        assert_eq!(edits[0].new_text, "a = 1\n");
+    }
+}

--- a/crates/eure-fmt/src/printer.rs
+++ b/crates/eure-fmt/src/printer.rs
@@ -1,0 +1,345 @@
+//! Wadler-style pretty printer.
+//!
+//! This module implements the document-to-string rendering algorithm
+//! based on Wadler's "A Prettier Printer" paper.
+
+use crate::config::FormatConfig;
+use crate::doc::Doc;
+
+/// Print mode determines how Line/SoftLine are rendered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Mode {
+    /// Flat mode: Line becomes space, SoftLine becomes empty
+    Flat,
+    /// Break mode: Line and SoftLine become newlines
+    Break,
+}
+
+/// A command on the printer's work stack.
+#[derive(Debug, Clone)]
+struct PrintCommand<'a> {
+    /// Current indentation level
+    indent: usize,
+    /// Current print mode
+    mode: Mode,
+    /// Document to print
+    doc: &'a Doc,
+}
+
+/// Pretty printer that renders Doc to String.
+pub struct Printer {
+    config: FormatConfig,
+}
+
+impl Printer {
+    /// Create a new printer with the given configuration.
+    pub fn new(config: FormatConfig) -> Self {
+        Self { config }
+    }
+
+    /// Print a document to a string.
+    pub fn print(&self, doc: &Doc) -> String {
+        let mut output = String::new();
+        let mut pos = 0; // Current column position
+        let mut stack = vec![PrintCommand {
+            indent: 0,
+            mode: Mode::Break,
+            doc,
+        }];
+
+        while let Some(cmd) = stack.pop() {
+            match cmd.doc {
+                Doc::Nil => {}
+
+                Doc::Text(s) => {
+                    output.push_str(s);
+                    pos += s.chars().count();
+                }
+
+                Doc::Line => {
+                    if cmd.mode == Mode::Flat {
+                        output.push(' ');
+                        pos += 1;
+                    } else {
+                        output.push('\n');
+                        output.push_str(&self.indent_string(cmd.indent));
+                        pos = cmd.indent * self.config.indent_width;
+                    }
+                }
+
+                Doc::SoftLine => {
+                    if cmd.mode == Mode::Flat {
+                        // Empty in flat mode
+                    } else {
+                        output.push('\n');
+                        output.push_str(&self.indent_string(cmd.indent));
+                        pos = cmd.indent * self.config.indent_width;
+                    }
+                }
+
+                Doc::HardLine => {
+                    output.push('\n');
+                    output.push_str(&self.indent_string(cmd.indent));
+                    pos = cmd.indent * self.config.indent_width;
+                }
+
+                Doc::Indent(inner) => {
+                    stack.push(PrintCommand {
+                        indent: cmd.indent + 1,
+                        mode: cmd.mode,
+                        doc: inner,
+                    });
+                }
+
+                Doc::Concat(left, right) => {
+                    // Push right first so left is processed first (stack is LIFO)
+                    stack.push(PrintCommand {
+                        indent: cmd.indent,
+                        mode: cmd.mode,
+                        doc: right,
+                    });
+                    stack.push(PrintCommand {
+                        indent: cmd.indent,
+                        mode: cmd.mode,
+                        doc: left,
+                    });
+                }
+
+                Doc::Group(inner) => {
+                    // Try flat mode first
+                    if self.fits(cmd.indent, pos, inner) {
+                        stack.push(PrintCommand {
+                            indent: cmd.indent,
+                            mode: Mode::Flat,
+                            doc: inner,
+                        });
+                    } else {
+                        stack.push(PrintCommand {
+                            indent: cmd.indent,
+                            mode: Mode::Break,
+                            doc: inner,
+                        });
+                    }
+                }
+
+                Doc::IfBreak { flat, broken } => {
+                    let chosen = if cmd.mode == Mode::Flat { flat } else { broken };
+                    stack.push(PrintCommand {
+                        indent: cmd.indent,
+                        mode: cmd.mode,
+                        doc: chosen,
+                    });
+                }
+            }
+        }
+
+        output
+    }
+
+    /// Check if a document fits within the remaining line width.
+    fn fits(&self, indent: usize, current_pos: usize, doc: &Doc) -> bool {
+        let remaining = self.config.max_width.saturating_sub(current_pos);
+        self.fits_within(remaining, indent, doc)
+    }
+
+    /// Check if a document fits within the given width.
+    fn fits_within(&self, mut remaining: usize, indent: usize, doc: &Doc) -> bool {
+        let mut stack = vec![(indent, doc)];
+
+        while let Some((ind, d)) = stack.pop() {
+            match d {
+                Doc::Nil => {}
+
+                Doc::Text(s) => {
+                    let len = s.chars().count();
+                    if len > remaining {
+                        return false;
+                    }
+                    remaining -= len;
+                }
+
+                Doc::Line => {
+                    // In flat mode, Line becomes a space
+                    if remaining == 0 {
+                        return false;
+                    }
+                    remaining -= 1;
+                }
+
+                Doc::SoftLine => {
+                    // In flat mode, SoftLine becomes empty
+                }
+
+                Doc::HardLine => {
+                    // HardLine always breaks, so the group doesn't fit flat
+                    return false;
+                }
+
+                Doc::Indent(inner) => {
+                    stack.push((ind + 1, inner));
+                }
+
+                Doc::Concat(left, right) => {
+                    stack.push((ind, right));
+                    stack.push((ind, left));
+                }
+
+                Doc::Group(inner) => {
+                    // Nested groups also try flat mode when checking fit
+                    stack.push((ind, inner));
+                }
+
+                Doc::IfBreak { flat, .. } => {
+                    // When checking fit, we're in flat mode
+                    stack.push((ind, flat));
+                }
+            }
+        }
+
+        true
+    }
+
+    /// Generate the indentation string.
+    fn indent_string(&self, level: usize) -> String {
+        let width = level * self.config.indent_width;
+        if self.config.use_tabs {
+            "\t".repeat(level)
+        } else {
+            " ".repeat(width)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn print(doc: &Doc) -> String {
+        Printer::new(FormatConfig::default()).print(doc)
+    }
+
+    fn print_width(doc: &Doc, width: usize) -> String {
+        Printer::new(FormatConfig {
+            max_width: width,
+            ..Default::default()
+        })
+        .print(doc)
+    }
+
+    #[test]
+    fn test_text() {
+        let doc = Doc::text("hello");
+        assert_eq!(print(&doc), "hello");
+    }
+
+    #[test]
+    fn test_concat() {
+        let doc = Doc::text("hello").concat(Doc::text(" world"));
+        assert_eq!(print(&doc), "hello world");
+    }
+
+    #[test]
+    fn test_line_in_break_mode() {
+        let doc = Doc::text("a").concat(Doc::line()).concat(Doc::text("b"));
+        // Without group, always in break mode
+        assert_eq!(print(&doc), "a\nb");
+    }
+
+    #[test]
+    fn test_group_fits() {
+        let doc = Doc::group(Doc::text("a").concat(Doc::line()).concat(Doc::text("b")));
+        // Short enough to fit on one line
+        assert_eq!(print_width(&doc, 80), "a b");
+    }
+
+    #[test]
+    fn test_group_breaks() {
+        let doc = Doc::group(
+            Doc::text("hello")
+                .concat(Doc::line())
+                .concat(Doc::text("world")),
+        );
+        // Too narrow, must break
+        assert_eq!(print_width(&doc, 5), "hello\nworld");
+    }
+
+    #[test]
+    fn test_indent() {
+        // Indent wraps the newline to get indented content
+        let doc = Doc::text("a").concat(Doc::indent(Doc::hardline().concat(Doc::text("b"))));
+        assert_eq!(print(&doc), "a\n  b");
+    }
+
+    #[test]
+    fn test_softline_flat() {
+        let doc = Doc::group(
+            Doc::text("[")
+                .concat(Doc::softline())
+                .concat(Doc::text("]")),
+        );
+        // Fits, so softline becomes empty
+        assert_eq!(print_width(&doc, 80), "[]");
+    }
+
+    #[test]
+    fn test_softline_break() {
+        let doc = Doc::group(
+            Doc::text("[")
+                .concat(Doc::softline())
+                .concat(Doc::text("very_long_content"))
+                .concat(Doc::softline())
+                .concat(Doc::text("]")),
+        );
+        // Doesn't fit, softline becomes newline
+        assert_eq!(print_width(&doc, 10), "[\nvery_long_content\n]");
+    }
+
+    #[test]
+    fn test_hardline_forces_break() {
+        let doc = Doc::group(
+            Doc::text("a")
+                .concat(Doc::hardline())
+                .concat(Doc::text("b")),
+        );
+        // HardLine forces break even in group
+        assert_eq!(print_width(&doc, 80), "a\nb");
+    }
+
+    #[test]
+    fn test_if_break() {
+        let trailing_comma = Doc::if_break(Doc::Nil, Doc::text(","));
+
+        let doc = Doc::group(
+            Doc::text("[")
+                .concat(Doc::softline())
+                .concat(Doc::text("a"))
+                .concat(trailing_comma.clone())
+                .concat(Doc::softline())
+                .concat(Doc::text("]")),
+        );
+
+        // Fits: no trailing comma
+        assert_eq!(print_width(&doc, 80), "[a]");
+
+        // Doesn't fit: trailing comma added
+        let doc = Doc::group(
+            Doc::text("[")
+                .concat(Doc::softline())
+                .concat(Doc::text("very_long_item"))
+                .concat(trailing_comma)
+                .concat(Doc::softline())
+                .concat(Doc::text("]")),
+        );
+        assert_eq!(print_width(&doc, 10), "[\nvery_long_item,\n]");
+    }
+
+    #[test]
+    fn test_nested_indent() {
+        // Nested indentation: each indent wraps its newline
+        let inner = Doc::indent(Doc::hardline().concat(Doc::text("c")));
+        let outer = Doc::indent(Doc::hardline().concat(Doc::text("b")).concat(inner));
+        let doc = Doc::text("a").concat(outer);
+
+        assert_eq!(print(&doc), "a\n  b\n    c");
+    }
+}

--- a/docs/adrs/0007-eure-fmt-ir-based-architecture.eure
+++ b/docs/adrs/0007-eure-fmt-ir-based-architecture.eure
@@ -1,0 +1,186 @@
+$schema: ../../assets/schemas/eure-adr.schema.eure
+
+id = "0007-eure-fmt-ir-based-architecture"
+title = "IR-Based Architecture for eure-fmt"
+status = "proposed"
+decision-date = `2025-12-13`
+tags = ["formatter", "architecture", "eure-fmt", "pretty-printing"]
+
+context = ```markdown
+The `eure-fmt` crate needs a complete redesign. The current state is essentially unimplemented,
+with only an "unformatter" (for testing) that randomly destroys formatting.
+
+**Requirements:**
+
+1. `eure fmt` - format files in place
+2. `eure fmt --check` - dry-run mode (exit 1 if changes needed)
+3. LSP formatting support via `eure-ls`
+4. Respect `max_width` constraint (inline vs multiline decisions)
+5. Preserve comments and trivia
+
+**Design considerations explored:**
+
+1. **Mutation commands** - Visitor collects CST mutation commands, apply atomically
+   - Problem: Complex to track, hard to reason about final output, difficult line-width decisions
+
+2. **Token stream** - Emit accepted tokens + inserted whitespace directly
+   - Problem: Reinvents layout engine for nested constructs, brittle with comments
+
+3. **IR-based (Wadler/Prettier style)** - CST → Doc IR → String
+   - Proven approach used by Prettier, gofmt-style formatters, and academic literature
+   - Clean separation of concerns
+   - Natural handling of line-width backtracking
+
+The mutation command approach was attempted previously and led to significant complexity.
+```
+
+decision = `````markdown
+Adopt an **IR-based architecture** following Wadler's "A Prettier Printer" algorithm,
+similar to Prettier and other modern formatters.
+
+## Core Pipeline
+
+```
+Parse → CST (with trivia) → Doc IR → String
+```
+
+## Doc IR Definition
+
+```rust
+pub enum Doc {
+    /// Literal text (no line breaks allowed within)
+    Text(String),
+
+    /// Line break: becomes space if group fits, newline if breaks
+    Line,
+
+    /// Soft line: becomes empty if group fits, newline if breaks
+    SoftLine,
+
+    /// Always a line break
+    HardLine,
+
+    /// Increase indent for nested content
+    Indent(Box<Doc>),
+
+    /// Concatenate docs
+    Concat(Vec<Doc>),
+
+    /// Try to fit on one line; if exceeds width, break at Line/SoftLine
+    Group(Box<Doc>),
+}
+```
+
+## Module Structure
+
+```
+crates/eure-fmt/
+├── src/
+│   ├── lib.rs           # Public API
+│   ├── doc.rs           # Doc IR enum + builder helpers
+│   ├── printer.rs       # Wadler algorithm (Doc → String)
+│   ├── builder.rs       # CST → Doc (uses CstVisitor)
+│   ├── trivia.rs        # Comment attachment model
+│   └── config.rs        # FormatConfig (max_width, indent, etc.)
+```
+
+## Public API
+
+```rust
+/// Format Eure source code
+pub fn format(input: &str, config: &FormatConfig) -> Result<String, FormatError>;
+
+/// Check if source is already formatted (for --check mode)
+pub fn check(input: &str, config: &FormatConfig) -> FormatCheckResult;
+
+/// For LSP: format and return text edits
+pub fn format_edits(input: &str, config: &FormatConfig) -> Result<Vec<TextEdit>, FormatError>;
+```
+
+## Trivia Attachment Model
+
+Comments attach deterministically:
+- **Leading trivia**: comments/blank lines before a token belong to that token
+- **Trailing trivia**: end-of-line comments belong to the preceding token
+
+## Formatting Policy
+
+- **Break-all-once-broken**: Once a structure goes multiline, all elements get their own line
+- **Trailing commas**: Add in multiline mode for stable diffs
+- **Treat max_width as guideline**: Long tokens (URLs, strings) may overflow
+`````
+
+consequences = ```markdown
+**Positive:**
+
+- Clean separation of concerns (parsing, IR building, rendering)
+- Line-width decisions handled naturally by the printer's backtracking
+- `--check` mode is simple string comparison
+- Easy to test: snapshot tests on Doc IR and final output
+- Well-studied algorithm with academic backing
+- Estimated ~2k lines vs rustfmt's ~50k (appropriate for data format complexity)
+- LSP integration straightforward via diff-based TextEdit generation
+
+**Negative:**
+
+- Requires implementing Wadler's algorithm (moderate complexity in printer)
+- Two-pass approach (build IR, then render) vs single-pass emit
+- Doc IR is an additional abstraction layer to understand
+
+**Neutral:**
+
+- Different from rustfmt's heuristic approach (justified: Eure is simpler than Rust)
+- No CST mutation needed (simpler, but means formatter is "stateless")
+
+**Stability Properties to Maintain:**
+
+1. **Idempotence**: `format(format(x)) == format(x)`
+2. **Round-trip**: `parse(format(x))` succeeds for valid inputs
+3. **Comment preservation**: All comments appear in output
+4. **Determinism**: Same input always produces same output
+```
+
+alternatives-considered = [
+  ```markdown
+  **CST Mutation Commands**
+
+  Original design idea: `fn format(&Cst) -> FormatSuggestions` where suggestions
+  include mutation commands to transform the CST.
+
+  Rejected because:
+  - Two representations to track (CST state + pending mutations)
+  - Commands may conflict or have ordering dependencies
+  - Hard to reason about final output until commands are applied
+  - Difficult to handle line-width decisions (need to simulate/predict)
+  - Previous implementation attempt showed significant complexity
+  ```,
+  ```markdown
+  **Token Stream Emission**
+
+  Walk CST, emit tokens directly to output buffer, inserting whitespace as needed.
+
+  Rejected because:
+  - Reinvents layout engine once nested constructs need optional line breaks
+  - Difficult to handle max_width without lookahead or backtracking
+  - Brittle with comments attached at various positions
+  - Essentially a less principled version of the IR approach
+  ```,
+  ```markdown
+  **Rustfmt-style Heuristic Approach**
+
+  Ad-hoc `rewrite_*` methods per node type, passing `(indent, width)` budget down,
+  returning `Option<String>`.
+
+  Rejected because:
+  - Designed for programming language complexity (Rust has macros, generics, etc.)
+  - Eure is a simple data format where algorithmic approach suffices
+  - Heuristic approach produces more code for marginal benefit
+  - Budget-passing creates complex retry logic at every call site
+  ```,
+]
+
+related-links = [
+  url`https://homepages.inf.ed.ac.uk/wadler/papers/prettier/prettier.pdf`,
+  url`https://prettier.io/docs/plugins.html`,
+  url`https://github.com/rust-lang/rustfmt/blob/master/Design.md`,
+]


### PR DESCRIPTION
Proposes a Wadler/Prettier-style IR-based architecture for the eure-fmt formatter with a CST → Doc IR → String pipeline. This replaces the previously attempted mutation command approach.

Key decisions:
- Doc IR with Group/Line/Indent primitives for layout
- Printer handles line-width backtracking automatically
- Simple string comparison for --check mode
- Break-all-once-broken policy for data format consistency