### PR TITLE
Add optional authors field to ADR schema

### DIFF
--- a/assets/schemas/eure-adr.schema.eure
+++ b/assets/schemas/eure-adr.schema.eure
@@ -35,3 +35,6 @@ alternatives-considered.$optional = true
 
 tags = [`text`]
 tags.$optional = true
+
+authors = [`text`]
+authors.$optional = true


### PR DESCRIPTION
Add optional authors array field to the ADR schema to track who authored or contributed to architecture decision records. This follows the same pattern as other optional metadata fields like tags and related-links.