### PR TITLE
Remove deprecated path expression syntax

### DIFF
--- a/crates/eure-schema/src/lib.rs
+++ b/crates/eure-schema/src/lib.rs
@@ -441,17 +441,8 @@ pub enum BindingStyle {
 
 /// Type reference (local or cross-schema)
 ///
-/// Spec: lines 506-510
-/// ```eure
-/// @variants.ref
-/// $variant: path
-/// starts-with = .$types
-/// length-min = 2
-/// length-max = 3
-/// ```
-///
-/// - Local reference (path length 2): `.$types.my-type`
-/// - Cross-schema reference (path length 3): `.$types.namespace.type-name`
+/// - Local reference: `$types.my-type`
+/// - Cross-schema reference: `$types.namespace.type-name`
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypeReference {
     /// Namespace for cross-schema references (None for local refs)

--- a/docs/data-types.md
+++ b/docs/data-types.md
@@ -29,7 +29,6 @@ Eure recommends **2-space indentation** for nested structures.
 - `tuple`
 - `unit`
 - `null`
-- `path`
 
 ## Officially Provided Types
 
@@ -174,10 +173,3 @@ The dot notation follows Eure's standard path syntax, making it consistent with 
 ## Null
 
 ## Datetime
-
-## Path
-
-Same syntax as section path and binding path.
-
-Notation as value: `path = .0.a.b.c`
-Notation as type: `"path"`

--- a/docs/schema-extensions.md
+++ b/docs/schema-extensions.md
@@ -176,22 +176,6 @@ url = `text.url`
 
 **Shorthand:** `text`, `text.rust`, `text.email`, etc.
 
-### Path Type
-
-Path type for document path values.
-
-```eure
-reference = `path`
-
-// With constraints
-@ ref {
-  $variant: path
-  starts-with = `config`
-  min-length = 2
-  max-length = 10
-}
-```
-
 ---
 
 ## Container Types


### PR DESCRIPTION
The path type primitive (e.g., `path = .path.to.something`) was previously removed from the language for simplicity, but references remained in documentation and comments. This commit completely removes all mentions of the path type to prevent confusion for developers and LLMs.

Changes:
- Remove path type from primitive types list in docs/data-types.md
- Remove "Path Type" section from docs/schema-extensions.md
- Update TypeReference comment in eure-schema/src/lib.rs to remove path type example

Note: The variant_path module remains unchanged as it serves a different purpose (tracking variant paths like `$variant = .ok.some.err`).