### PR TITLE
Fix conflicting ADR numbers from parallel work

### DIFF
--- a/docs/adrs/0006-objectkey-design.eure
+++ b/docs/adrs/0006-objectkey-design.eure
@@ -1,6 +1,6 @@
 $schema: ../../assets/schemas/eure-adr.schema.eure
 
-id = "0005-objectkey-design"
+id = "0006-objectkey-design"
 title = "ObjectKey Type Design: Restricted Key Types for Reliable Maps"
 status = "accepted"
 decision-date = `2025-12-11`

--- a/docs/adrs/0007-codeblock-attributes-via-extensions.eure
+++ b/docs/adrs/0007-codeblock-attributes-via-extensions.eure
@@ -1,6 +1,6 @@
 $schema: ../../assets/schemas/eure-adr.schema.eure
 
-id = "0006-codeblock-attributes-via-extensions"
+id = "0007-codeblock-attributes-via-extensions"
 title = "Code Block Attributes via Extension Syntax"
 status = "accepted"
 decision-date = `2025-12-13`

--- a/docs/adrs/0008-codeblock-indentation-stripping.eure
+++ b/docs/adrs/0008-codeblock-indentation-stripping.eure
@@ -1,6 +1,6 @@
 $schema: ../../assets/schemas/eure-adr.schema.eure
 
-id = "0007-codeblock-indentation-stripping"
+id = "0008-codeblock-indentation-stripping"
 title = "Code Block Indentation Stripping Based on Closing Delimiter"
 status = "accepted"
 decision-date = `2025-12-13`

--- a/docs/adrs/0009-comma-rules-for-collections.eure
+++ b/docs/adrs/0009-comma-rules-for-collections.eure
@@ -1,6 +1,6 @@
 $schema: ../../assets/schemas/eure-adr.schema.eure
 
-id = "0007-comma-rules-for-collections"
+id = "0009-comma-rules-for-collections"
 title = "Comma Rules: Optional in Objects, Required in Arrays/Tuples"
 status = "accepted"
 decision-date = `2025-12-13`

--- a/docs/adrs/0010-eure-fmt-ir-based-architecture.eure
+++ b/docs/adrs/0010-eure-fmt-ir-based-architecture.eure
@@ -1,6 +1,6 @@
 $schema: ../../assets/schemas/eure-adr.schema.eure
 
-id = "0007-eure-fmt-ir-based-architecture"
+id = "0010-eure-fmt-ir-based-architecture"
 title = "IR-Based Architecture for eure-fmt"
 status = "proposed"
 decision-date = `2025-12-13`


### PR DESCRIPTION
Resolved duplicate ADR numbers caused by parallel work:
- Renumbered 0005-objectkey-design to 0006
- Renumbered 0006-codeblock-attributes to 0007
- Renumbered 0007-codeblock-indentation to 0008
- Renumbered 0007-comma-rules to 0009
- Renumbered 0007-eure-fmt-ir to 0010

Updated all internal ID fields to match new numbers. All cross-references verified and remain correct.