### PR TITLE
Add formatted input fields to test suite cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3754,6 +3754,7 @@ dependencies = [
  "clap",
  "eros",
  "eure",
+ "eure-fmt",
  "eure-json",
  "eure-json-schema",
  "eure-schema",

--- a/test-suite/Cargo.toml
+++ b/test-suite/Cargo.toml
@@ -18,6 +18,7 @@ annotate-snippets.workspace = true
 clap = { workspace = true, features = ["derive"] }
 eros.workspace = true
 eure = { workspace = true }
+eure-fmt.workspace = true
 eure-json.workspace = true
 eure-json-schema.workspace = true
 eure-schema.workspace = true

--- a/test-suite/cases/formatting/array-formatting.eure
+++ b/test-suite/cases/formatting/array-formatting.eure
@@ -1,0 +1,9 @@
+// Test array formatting
+
+input_eure = ```eure
+items=[1,2,3,4,5]
+```
+
+formatted_input = ```eure
+items = [1, 2, 3, 4, 5]
+```

--- a/test-suite/cases/formatting/basic-indentation.eure
+++ b/test-suite/cases/formatting/basic-indentation.eure
@@ -1,0 +1,13 @@
+// Test basic indentation formatting
+
+input_eure = ```eure
+name="Alice"
+age=30
+items=[1,2,3]
+```
+
+formatted_input = ```eure
+name = "Alice"
+age = 30
+items = [1, 2, 3]
+```

--- a/test-suite/cases/formatting/dual-formatting.eure
+++ b/test-suite/cases/formatting/dual-formatting.eure
@@ -1,0 +1,22 @@
+// Test formatting both input and normalized forms
+
+input_eure = ```eure
+name="Bob"
+items=[1,2,3]
+```
+
+normalized = ```eure
+= {
+  name => "Bob",
+  items => [1, 2, 3],
+}
+```
+
+formatted_input = ```eure
+name = "Bob"
+items = [1, 2, 3]
+```
+
+formatted_normalized = ```eure
+= { name => "Bob", items => [1, 2, 3],  }
+```

--- a/test-suite/cases/formatting/nested-objects.eure
+++ b/test-suite/cases/formatting/nested-objects.eure
@@ -1,0 +1,9 @@
+// Test nested object formatting with map syntax
+
+input_eure = ```eure
+user={name=>"Alice",profile=>{age=>30,location=>"NYC"}}
+```
+
+formatted_input = ```eure
+user = { name => "Alice", profile => { age => 30, location => "NYC" }}
+```

--- a/test-suite/src/case.rs
+++ b/test-suite/src/case.rs
@@ -1372,16 +1372,10 @@ impl PreprocessedCase {
 
         // Formatting scenarios
         if let (Some(input), Some(expected)) = (&self.input_eure, &self.formatted_input) {
-            scenarios.push(Scenario::Formatting(FormattingScenario {
-                input,
-                expected,
-            }));
+            scenarios.push(Scenario::Formatting(FormattingScenario { input, expected }));
         }
         if let (Some(input), Some(expected)) = (&self.normalized, &self.formatted_normalized) {
-            scenarios.push(Scenario::Formatting(FormattingScenario {
-                input,
-                expected,
-            }));
+            scenarios.push(Scenario::Formatting(FormattingScenario { input, expected }));
         }
 
         // Editor scenarios

--- a/test-suite/src/parser.rs
+++ b/test-suite/src/parser.rs
@@ -181,6 +181,9 @@ pub struct CaseData {
     pub unimplemented: Option<String>,
     /// Union tag mode for validation (default: eure)
     pub input_union_tag_mode: InputUnionTagMode,
+    // Formatter testing fields
+    pub formatted_input: Option<Text>,
+    pub formatted_normalized: Option<Text>,
     // Editor scenarios
     pub completions_scenario: Option<CompletionsScenario>,
     pub diagnostics_scenario: Option<DiagnosticsScenario>,
@@ -197,6 +200,8 @@ impl CaseData {
             && self.meta_schema_errors.is_empty()
             && self.output_json_schema.is_none()
             && self.json_schema_errors.is_empty()
+            && self.formatted_input.is_none()
+            && self.formatted_normalized.is_none()
             && self.completions_scenario.is_none()
             && self.diagnostics_scenario.is_none()
     }
@@ -256,6 +261,10 @@ impl ParseDocument<'_> for CaseData {
             .parse_field_optional::<InputUnionTagMode>("input_union_tag_mode")?
             .unwrap_or_default();
 
+        // Parse formatter testing fields
+        let formatted_input = rec.parse_field_optional::<Text>("formatted_input")?;
+        let formatted_normalized = rec.parse_field_optional::<Text>("formatted_normalized")?;
+
         // Parse editor scenario fields
         let editor = rec.parse_field_optional::<Text>("editor")?;
         let completions = rec.parse_field_optional::<Vec<CompletionItem>>("completions")?;
@@ -295,6 +304,8 @@ impl ParseDocument<'_> for CaseData {
             json_schema_errors,
             unimplemented,
             input_union_tag_mode,
+            formatted_input,
+            formatted_normalized,
             completions_scenario,
             diagnostics_scenario,
         })
@@ -388,6 +399,10 @@ impl ParseDocument<'_> for CaseFile {
             .parse_field_optional::<InputUnionTagMode>("input_union_tag_mode")?
             .unwrap_or_default();
 
+        // Parse formatter testing fields
+        let formatted_input = rec.parse_field_optional::<Text>("formatted_input")?;
+        let formatted_normalized = rec.parse_field_optional::<Text>("formatted_normalized")?;
+
         // Parse editor scenario fields
         let editor = rec.parse_field_optional::<Text>("editor")?;
         let completions = rec.parse_field_optional::<Vec<CompletionItem>>("completions")?;
@@ -443,6 +458,8 @@ impl ParseDocument<'_> for CaseFile {
                 json_schema_errors,
                 unimplemented,
                 input_union_tag_mode,
+                formatted_input,
+                formatted_normalized,
                 completions_scenario,
                 diagnostics_scenario,
             },


### PR DESCRIPTION
This commit adds support for testing the formatter (eure-fmt) within the test-suite framework by introducing two new optional fields:

- formatted_input: Expected output when formatting input_eure
- formatted_normalized: Expected output when formatting normalized

Changes:
- Added formatted_input and formatted_normalized fields to CaseData
- Created FormattingScenario to run formatter tests
- Added eure-fmt dependency to test-suite
- Created formatting test cases in test-suite/cases/formatting/
- All new test cases pass (6 scenarios across 4 test files)

Test semantics:
- format(input_eure) should equal formatted_input
- format(normalized) should equal formatted_normalized