### PR TITLE
Rename ValueVisitor to CstInterpreter

### DIFF
--- a/crates/eure/src/document.rs
+++ b/crates/eure/src/document.rs
@@ -1,4 +1,4 @@
-mod value_visitor;
+mod interpreter;
 
 use eros::Union as _;
 use eure_document::document::constructor::ScopeError;
@@ -9,7 +9,7 @@ pub use eure_document::parse;
 use eure_document::text::TextParseError;
 use eure_parol::EureParseError;
 
-use crate::document::value_visitor::ValueVisitor;
+use crate::document::interpreter::CstInterpreter;
 use eure_tree::prelude::*;
 use eure_tree::tree::InputSpan;
 use std::collections::HashMap;
@@ -161,7 +161,7 @@ pub fn parse_to_document(
 }
 
 pub fn cst_to_document(input: &str, cst: &Cst) -> Result<EureDocument, DocumentConstructionError> {
-    let mut visitor = ValueVisitor::new(input);
+    let mut visitor = CstInterpreter::new(input);
     visitor.visit_root_handle(cst.root_handle(), cst)?;
     Ok(visitor.into_document())
 }
@@ -174,7 +174,7 @@ pub fn cst_to_document_and_origin_map(
     input: &str,
     cst: &Cst,
 ) -> Result<(EureDocument, OriginMap), DocumentConstructionError> {
-    let mut visitor = ValueVisitor::new(input);
+    let mut visitor = CstInterpreter::new(input);
     visitor.visit_root_handle(cst.root_handle(), cst)?;
     Ok(visitor.into_document_and_origin_map())
 }

--- a/docs/completion_architecture.md
+++ b/docs/completion_architecture.md
@@ -107,8 +107,8 @@ enum CompletionPosition {
 
 ```rust
 // CompletionVisitor is specialized for finding completion contexts
-// For full value extraction, use the new ValueVisitor API:
-//   let mut visitor = ValueVisitor::new(input);
+// For full value extraction, use the new CstInterpreter API:
+//   let mut visitor = CstInterpreter::new(input);
 //   visitor.visit_eure(handle, view, tree)?;
 //   let document: EureDocument = visitor.into_document();
 //
@@ -146,7 +146,7 @@ struct CompletionVisitor<'a> {
 }
 
 // Note: This implements CstVisitor for completion-specific traversal
-// The new ValueVisitor uses similar path building with build_path_segments()
+// The new CstInterpreter uses similar path building with build_path_segments()
 impl<'a> CstVisitor for CompletionVisitor<'a> {
     fn visit_section(&mut self, handle: SectionHandle, view: SectionView, tree: &Cst) -> Result<(), Self::Error> {
         let span = self.get_span(handle, tree);

--- a/docs/completion_with_error_recovery.md
+++ b/docs/completion_with_error_recovery.md
@@ -92,8 +92,8 @@ impl ErrorBasedCompletion {
     }
     
     fn extract_path_from_cst(&self, cst: &Cst, error_loc: Location) -> PathContext {
-        // Use ValueVisitor to extract paths from the CST
-        // The new ValueVisitor builds paths directly using PathSegment
+        // Use CstInterpreter to extract paths from the CST
+        // The new CstInterpreter builds paths directly using PathSegment
         let mut visitor = PathExtractorVisitor {
             target_location: error_loc,
             current_path: vec![],
@@ -136,7 +136,7 @@ impl ErrorBasedCompletion {
 }
 
 // PathExtractorVisitor is a specialized visitor for error recovery
-// It's separate from ValueVisitor which is used for complete value extraction
+// It's separate from CstInterpreter which is used for complete value extraction
 struct PathExtractorVisitor {
     target_location: Location,
     current_path: Vec<String>,
@@ -147,15 +147,15 @@ struct PathExtractorVisitor {
 }
 
 // Note: This implements CstVisitor directly for error recovery purposes
-// For complete value extraction, use the new ValueVisitor API:
-//   let mut visitor = ValueVisitor::new(input);
+// For complete value extraction, use the new CstInterpreter API:
+//   let mut visitor = CstInterpreter::new(input);
 //   visitor.visit_eure(handle, view, tree)?;
 //   let document = visitor.into_document();
 impl CstVisitor for PathExtractorVisitor {
     fn visit_section(&mut self, section: &Section) {
         self.in_section = true;
         // Extract path from section keys
-        // ValueVisitor would use build_path_segments() for this
+        // CstInterpreter would use build_path_segments() for this
         let keys_path = self.extract_keys_path(&section.keys);
         self.current_path = keys_path;
         

--- a/docs/cst-and-visitor.md
+++ b/docs/cst-and-visitor.md
@@ -200,13 +200,13 @@ fn visit(cst: &Cst) -> Result<(), CstConstructError> {
 
 The combination of auto-generated, type-safe node access (`Handle` and `View`) and the flexible `CstVisitor` trait provides a powerful foundation for interacting with Eure CSTs.
 
-## ValueVisitor: Extracting Values from CST
+## CstInterpreter: Extracting Values from CST
 
-While the `CstVisitor` trait provides a generic way to traverse the CST, the `ValueVisitor` struct (in `value_visitor.rs`) provides a specialized implementation for extracting structured data from Eure documents.
+While the `CstVisitor` trait provides a generic way to traverse the CST, the `CstInterpreter` struct (in `value_visitor.rs`) provides a specialized implementation for extracting structured data from Eure documents.
 
 ### Overview
 
-`ValueVisitor` implements `CstVisitor` to build an `EureDocument` - a path-based document structure that represents the hierarchical data in your Eure file. The key architectural point is that **`ValueVisitor` produces `EureDocument`, not `Value` directly**. This design preserves CST handles for span tracking and error reporting.
+`CstInterpreter` implements `CstVisitor` to build an `EureDocument` - a path-based document structure that represents the hierarchical data in your Eure file. The key architectural point is that **`CstInterpreter` produces `EureDocument`, not `Value` directly**. This design preserves CST handles for span tracking and error reporting.
 
 The visitor handles all the complexity of:
 
@@ -221,7 +221,7 @@ The visitor handles all the complexity of:
 
 The correct data flow is:
 
-1. **ValueVisitor traverses the CST** and builds an `EureDocument`
+1. **CstInterpreter traverses the CST** and builds an `EureDocument`
 2. **EureDocument preserves CST handles** for span tracking and diagnostics
 3. **EureDocument can be converted to Value** when spans aren't needed
 
@@ -233,10 +233,10 @@ This architecture ensures that:
 ### Basic Usage
 
 ```rust
-use eure_tree::value_visitor::ValueVisitor;
+use eure_tree::value_visitor::CstInterpreter;
 
 // Create a visitor with your input text
-let mut visitor = ValueVisitor::new(input);
+let mut visitor = CstInterpreter::new(input);
 
 // Visit the CST (typically done by the parser)
 visitor.visit_eure(eure_handle, eure_view, &tree)?;
@@ -253,7 +253,7 @@ schema_validator.validate(&document); // Can report exact error locations
 
 ### Key Features
 
-1. **Path-Based Construction**: Instead of manually building nested structures, `ValueVisitor` uses `EureDocument`'s path-based API:
+1. **Path-Based Construction**: Instead of manually building nested structures, `CstInterpreter` uses `EureDocument`'s path-based API:
    ```rust
    // Internally, bindings like `user.name = "Alice"` become:
    document.insert_node(vec![PathSegment::Ident("user"), PathSegment::Ident("name")], Value::String("Alice"))
@@ -279,16 +279,16 @@ schema_validator.validate(&document); // Can report exact error locations
 
 ### Implementation Details
 
-The new `ValueVisitor` is significantly simpler than previous implementations:
+The new `CstInterpreter` is significantly simpler than previous implementations:
 
-- **Single Struct Design**: Everything is contained in `ValueVisitor` - no separate `Values` struct
+- **Single Struct Design**: Everything is contained in `CstInterpreter` - no separate `Values` struct
 - **Direct Document Building**: Uses `EureDocument::insert_node()` for all insertions
 - **Minimal State**: Only caches values when needed for references
 - **No Post-Processing**: Variants and extensions are handled during traversal
 
 ### Comparison with Direct CstVisitor Implementation
 
-While you could implement `CstVisitor` directly for value extraction, `ValueVisitor` provides:
+While you could implement `CstVisitor` directly for value extraction, `CstInterpreter` provides:
 
 - Pre-built path segment construction from keys
 - Automatic handling of array syntax
@@ -296,7 +296,7 @@ While you could implement `CstVisitor` directly for value extraction, `ValueVisi
 - Value type conversion (strings, numbers, arrays, etc.)
 - Extension and variant handling
 
-This makes `ValueVisitor` the recommended approach for extracting structured data from Eure documents.
+This makes `CstInterpreter` the recommended approach for extracting structured data from Eure documents.
 
 ### Advanced Use Case: Custom Facade and Dependency Graphs
 

--- a/docs/euredocument-vs-value.md
+++ b/docs/euredocument-vs-value.md
@@ -157,7 +157,7 @@ Converting from `Value` to `EureDocument` requires synthetic handle creation:
 // This is typically done during parsing, not direct conversion
 // Values are built into EureDocument during the parsing phase
 let tree = parse(input)?;
-let mut visitor = ValueVisitor::new(input);
+let mut visitor = CstInterpreter::new(input);
 tree.visit_from_root(&mut visitor)?;
 let document = visitor.into_document();
 ```
@@ -200,7 +200,7 @@ let document = visitor.into_document();
 // Using EureDocument for rich error reporting
 pub fn validate_with_diagnostics(input: &str) -> Vec<Diagnostic> {
     let tree = parse(input)?;
-    let mut visitor = ValueVisitor::new(input);
+    let mut visitor = CstInterpreter::new(input);
     tree.visit_from_root(&mut visitor)?;
     let document = visitor.into_document();
 
@@ -323,7 +323,7 @@ pub struct EureProcessor {
 impl EureProcessor {
     pub fn new(input: &str) -> Result<Self, Error> {
         let tree = parse(input)?;
-        let mut visitor = ValueVisitor::new(input);
+        let mut visitor = CstInterpreter::new(input);
         tree.visit_from_root(&mut visitor)?;
         let document = visitor.into_document();
         let value = document.to_value();


### PR DESCRIPTION
The new name better reflects its role: interpreting the CST using
operational semantics to produce DocumentConstructor commands and
build the OriginMap for error span resolution.