### PR TITLE
Add assert_unbound for sections in Eure

### DIFF
--- a/crates/eure/src/document/interpreter.rs
+++ b/crates/eure/src/document/interpreter.rs
@@ -685,10 +685,18 @@ impl<F: CstFacade> CstVisitor<F> for CstInterpreter<'_> {
         } = view;
         let scope = self.document.begin_scope();
 
-        // Navigate through the keys (no require_hole for sections)
+        // Navigate through the keys
         self.visit_keys_handle(keys, tree)?;
 
+        // Validate section target is unbound
         let node_id = self.document.current_node_id();
+        self.document
+            .require_hole()
+            .map_err(|e| DocumentConstructionError::DocumentInsert {
+                error: e,
+                node_id: handle.node_id(),
+            })?;
+
         self.record_origin(node_id, handle.node_id());
         self.visit_section_body_handle(section_body, tree)?;
         self.document.end_scope(scope)?;

--- a/docs/spec/alpha.md
+++ b/docs/spec/alpha.md
@@ -700,7 +700,7 @@ port = 8080
 
 ```
 begin_scope()
-  navigate("server")  // No assert_unbound() - sections allow additive binding
+  navigate("server") assert_unbound()
   begin_scope()
     navigate("host") assert_unbound() bind("localhost")
   end_scope()
@@ -723,7 +723,7 @@ value = 2
 ```
 // First array element
 begin_scope()
-  navigate("items") navigate([])  // [] appends new element
+  navigate("items") navigate([]) assert_unbound()  // [] appends new element
   begin_scope()
     navigate("value") assert_unbound() bind(1)
   end_scope()
@@ -731,7 +731,7 @@ end_scope()
 
 // Second array element
 begin_scope()
-  navigate("items") navigate([])  // [] appends another element
+  navigate("items") navigate([]) assert_unbound()  // [] appends another element
   begin_scope()
     navigate("value") assert_unbound() bind(2)
   end_scope()
@@ -749,8 +749,8 @@ end_scope()
 
 ```
 begin_scope()
-  navigate("config")  // Block section creates sub-document context
-  assert_unbound() bind("default")  // Value binding
+  navigate("config") assert_unbound()
+  bind("default")  // Value binding
   begin_scope()
     navigate($tag) assert_unbound() bind("meta")  // Extension binding
   end_scope()


### PR DESCRIPTION
Sections (`@ a` and `@ a { ... }`) now require the target position to be
unbound, similar to regular bindings. This aligns with TOML's behavior
where re-defining the same table is an error.

Changes:
- Update interpreter.rs to call require_hole() after navigating to section target
- Update alpha.md spec examples to include assert_unbound() for sections