### PR TITLE
Preserve single blank lines between bindings in formatter

### DIFF
--- a/test-suite/cases/formatting/blank-line-handling.eure
+++ b/test-suite/cases/formatting/blank-line-handling.eure
@@ -1,0 +1,30 @@
+// Test blank line preservation between bindings
+// Single blank lines should be preserved, multiple blank lines normalized to one
+
+// Basic: single blank line between bindings should be preserved
+input_eure = ```eure
+name = "Alice"
+
+age = 30
+```
+
+formatted_input = ```eure
+name = "Alice"
+
+age = 30
+```
+
+// Multiple consecutive blank lines should be normalized to one
+normalized = ```eure
+name = "Alice"
+
+
+
+age = 30
+```
+
+formatted_normalized = ```eure
+name = "Alice"
+
+age = 30
+```


### PR DESCRIPTION
The formatter now preserves intentional blank lines between bindings:
- Single blank lines are preserved (user's semantic grouping intent)
- Multiple consecutive blank lines are normalized to one

This follows the common pattern used by gofmt, rustfmt, prettier, etc.