### PR TITLE
Improve JSON Schema forward conversion and add JsonSchemaData enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1623,7 +1623,10 @@ dependencies = [
 name = "eure-json-schema"
 version = "0.1.0"
 dependencies = [
+ "eure",
  "eure-document",
+ "eure-json",
+ "eure-parol",
  "eure-schema",
  "indexmap",
  "num-bigint",

--- a/crates/eure-json-schema/Cargo.toml
+++ b/crates/eure-json-schema/Cargo.toml
@@ -10,7 +10,10 @@ license = "MIT OR Apache-2.0"
 keywords = ["eure", "json-schema", "schema", "validation"]
 
 [dependencies]
+eure = { workspace = true }
 eure-document = { workspace = true }
+eure-json = { workspace = true }
+eure-parol = { workspace = true }
 eure-schema = { workspace = true }
 indexmap = { workspace = true }
 num-bigint = { workspace = true }

--- a/crates/eure-json-schema/src/json_schema.rs
+++ b/crates/eure-json-schema/src/json_schema.rs
@@ -15,6 +15,10 @@ pub struct SchemaMetadata {
     pub title: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub examples: Option<Vec<serde_json::Value>>,
 }
 
 /// JSON Schema root type
@@ -259,6 +263,11 @@ pub struct NullSchema {
 pub struct ArraySchema {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub items: Option<Box<JsonSchema>>,
+
+    /// Tuple validation: each element must match the corresponding schema (JSON Schema 2020-12)
+    /// In Draft-07, this was called "items" with an array value, but we use prefixItems for clarity
+    #[serde(rename = "prefixItems", skip_serializing_if = "Option::is_none")]
+    pub prefix_items: Option<Vec<JsonSchema>>,
 
     #[serde(rename = "minItems", skip_serializing_if = "Option::is_none")]
     pub min_items: Option<u32>,
@@ -650,6 +659,8 @@ mod tests {
             metadata: SchemaMetadata {
                 title: Some("Email".to_string()),
                 description: Some("User email address".to_string()),
+                deprecated: None,
+                examples: None,
             },
         }));
 
@@ -833,6 +844,8 @@ mod tests {
             metadata: SchemaMetadata {
                 title: Some("Age".to_string()),
                 description: Some("User's age in years".to_string()),
+                deprecated: None,
+                examples: None,
             },
         }));
 
@@ -894,6 +907,8 @@ mod tests {
             metadata: SchemaMetadata {
                 title: Some("User Reference".to_string()),
                 description: Some("Reference to User type".to_string()),
+                deprecated: None,
+                examples: None,
             },
         });
 

--- a/test-suite/cases/eure-schema-to-json-schema/errors/tuple-constraints-not-supported.eure
+++ b/test-suite/cases/eure-schema-to-json-schema/errors/tuple-constraints-not-supported.eure
@@ -1,8 +1,0 @@
-// Test error: Tuple constraints cannot be fully represented in JSON Schema
-
-schema = ```eure
-$variant = "tuple"
-elements = [`text`, `integer`]
-```
-
-json_schema_errors[] = "Tuple constraints not fully supported in JSON Schema"

--- a/test-suite/cases/eure-schema-to-json-schema/metadata-default.eure
+++ b/test-suite/cases/eure-schema-to-json-schema/metadata-default.eure
@@ -1,0 +1,17 @@
+// Test: Default value conversion in metadata
+
+schema = ```eure
+name = `text`
+name.$default = "anonymous"
+```
+
+output_json_schema = ```json
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "name": {"type": "string", "default": "anonymous"}
+  },
+  "required": ["name"]
+}
+```

--- a/test-suite/cases/eure-schema-to-json-schema/metadata-deprecated.eure
+++ b/test-suite/cases/eure-schema-to-json-schema/metadata-deprecated.eure
@@ -1,0 +1,17 @@
+// Test: Deprecated metadata conversion
+
+schema = ```eure
+old_field = `text`
+old_field.$deprecated = true
+```
+
+output_json_schema = ```json
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "old_field": {"type": "string", "deprecated": true}
+  },
+  "required": ["old_field"]
+}
+```

--- a/test-suite/cases/eure-schema-to-json-schema/tuple-basic.eure
+++ b/test-suite/cases/eure-schema-to-json-schema/tuple-basic.eure
@@ -1,0 +1,20 @@
+// Test: Tuple schema conversion to JSON Schema
+// Tuples are now supported using prefixItems (JSON Schema 2020-12)
+
+schema = ```eure
+$variant = "tuple"
+elements = [`text`, `integer`]
+```
+
+output_json_schema = ```json
+{
+  "type": "array",
+  "prefixItems": [
+    {"type": "string"},
+    {"type": "integer"}
+  ],
+  "items": false,
+  "minItems": 2,
+  "maxItems": 2
+}
+```


### PR DESCRIPTION
- Add JsonSchemaData enum with Both/Separate variants for bidirectional testing
  (similar to JsonData for JSON conversion tests)
- Fix forward conversion missing features:
  - Add default value conversion for text, integer, float, boolean schemas
  - Implement tuple schema support using prefixItems (JSON Schema 2020-12)
  - Add deprecated and examples metadata conversion
- Add prefixItems field to ArraySchema for tuple validation
- Add deprecated and examples fields to SchemaMetadata
- Update test suite to use new JsonSchemaData type
- Add new test cases for tuple, default, and deprecated metadata
- Remove TupleConstraintsNotSupported error (tuples now fully supported)