### PR TITLE
Add parse_ext container attribute for ParseDocument derive

### DIFF
--- a/crates/eure-macros/src/attrs/container.rs
+++ b/crates/eure-macros/src/attrs/container.rs
@@ -12,4 +12,8 @@ pub struct ContainerAttrs {
     /// Renames all struct variant fields in an enum.
     /// Unlike `rename_all`, this only applies to fields within struct variants.
     pub rename_all_fields: Option<RenameAll>,
+    /// Parse fields from extension namespace ($ext-type) instead of record fields.
+    /// When true, uses `ctx.parse_extension()` and `ext.parse_ext()` instead of
+    /// `ctx.parse_record()` and `rec.parse_field()`.
+    pub parse_ext: bool,
 }

--- a/crates/eure-macros/src/config.rs
+++ b/crates/eure-macros/src/config.rs
@@ -7,6 +7,8 @@ pub struct MacroConfig {
     pub document_crate: TokenStream,
     pub rename_all: Option<RenameAll>,
     pub rename_all_fields: Option<RenameAll>,
+    /// Parse fields from extension namespace instead of record fields.
+    pub parse_ext: bool,
 }
 
 impl MacroConfig {
@@ -20,6 +22,7 @@ impl MacroConfig {
             document_crate,
             rename_all: attrs.rename_all,
             rename_all_fields: attrs.rename_all_fields,
+            parse_ext: attrs.parse_ext,
         }
     }
 }

--- a/crates/eure-macros/src/parse_document/parse_record/tests.rs
+++ b/crates/eure-macros/src/parse_document/parse_record/tests.rs
@@ -187,3 +187,63 @@ fn test_named_fields_struct_with_rename_all_kebab_case() {
         .to_string()
     );
 }
+
+#[test]
+fn test_parse_ext_basic() {
+    let input = generate(parse_quote! {
+        #[eure(parse_ext)]
+        struct ExtFields {
+            optional: bool,
+            deprecated: bool,
+        }
+    });
+    assert_eq!(
+        input.to_string(),
+        quote! {
+            impl<'doc,> ::eure::document::parse::ParseDocument<'doc> for ExtFields<> {
+                type Error = ::eure::document::parse::ParseError;
+
+                fn parse(ctx: &::eure::document::parse::ParseContext<'doc>) -> Result<Self, Self::Error> {
+                    let mut ext = ctx.parse_extension();
+                    let value = ExtFields {
+                        optional: ext.parse_ext("optional")?,
+                        deprecated: ext.parse_ext("deprecated")?
+                    };
+                    ext.allow_unknown_extensions();
+                    Ok(value)
+                }
+            }
+        }
+        .to_string()
+    );
+}
+
+#[test]
+fn test_parse_ext_with_rename_all() {
+    let input = generate(parse_quote! {
+        #[eure(parse_ext, rename_all = "kebab-case")]
+        struct ExtFields {
+            binding_style: String,
+            deny_untagged: bool,
+        }
+    });
+    assert_eq!(
+        input.to_string(),
+        quote! {
+            impl<'doc,> ::eure::document::parse::ParseDocument<'doc> for ExtFields<> {
+                type Error = ::eure::document::parse::ParseError;
+
+                fn parse(ctx: &::eure::document::parse::ParseContext<'doc>) -> Result<Self, Self::Error> {
+                    let mut ext = ctx.parse_extension();
+                    let value = ExtFields {
+                        binding_style: ext.parse_ext("binding-style")?,
+                        deny_untagged: ext.parse_ext("deny-untagged")?
+                    };
+                    ext.allow_unknown_extensions();
+                    Ok(value)
+                }
+            }
+        }
+        .to_string()
+    );
+}


### PR DESCRIPTION
Add support for parsing struct fields from extension namespace ($ext-type)
instead of record fields. When #[eure(parse_ext)] is specified on a struct,
the generated code uses ctx.parse_extension() and ext.parse_ext() instead of
ctx.parse_record() and rec.parse_field().

This allows types like ParsedRecordFieldSchema to be derived rather than
manually implemented.