### PR TITLE
Add eure-md schema for structured markdown documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 !example.schema.eure
 !eure-schema.schema.eure
 !assets/**/*.eure
+!**/*.eumd
 
 !playground/**/*.json
 !playground/**/*.js

--- a/Eure.eure
+++ b/Eure.eure
@@ -11,5 +11,9 @@ schema = "assets/schemas/eure-schema.schema.eure"
 @ targets.examples
 globs = ["assets/examples/**/*.eure"]
 
+@ targets.eumd
+globs = ["**/*.eumd"]
+schema = "assets/schemas/eure-md.schema.eure"
+
 @ cli
 default-targets = ["adr", "schemas"]

--- a/assets/examples/example.eumd
+++ b/assets/examples/example.eumd
@@ -1,0 +1,122 @@
+// Example Eure Markdown document
+$schema: ../../assets/schemas/eure-md.schema.eure
+
+// ---- Frontmatter ----
+title = markdown`Eure Mark: A Structured Document Format`
+authors = [
+  { name => "Alice", affiliation => "Eure Labs" },
+  "Bob"
+]
+date = `2025-01-15`
+tags = ["eure", "markdown", "documentation"]
+draft = false
+
+description = ```markdown
+This document demonstrates the **eure-mark** format, which combines
+Eure's structured data model with Markdown content.
+```
+
+// ---- Bibliography (BibTeX) ----
+cites = ```bibtex
+@article{knuth1984,
+  author = "Donald E. Knuth",
+  title = "Literate Programming",
+  journal = "The Computer Journal",
+  volume = "27",
+  number = "2",
+  pages = "97--111",
+  year = 1984
+}
+
+@book{lamport1994,
+  author = "Leslie Lamport",
+  title = "LaTeX: A Document Preparation System",
+  publisher = "Addison-Wesley",
+  year = 1994,
+  edition = "2nd"
+}
+```
+
+@ footnotes.impl-detail {
+  content = markdown`Implementation details may change in future versions.`
+}
+
+@ footnotes.see-spec {
+  content = markdown`See the [CommonMark Spec](https://commonmark.org) for details.`
+}
+
+@ sections.intro {
+  header = markdown`Introduction`
+  body = ```markdown
+  Traditional Markdown documents have **implicit structure** based on heading levels.
+  This can lead to ambiguity and makes programmatic manipulation difficult.
+
+  Eure-mark addresses this by making the section hierarchy **explicit**!footnote[impl-detail].
+  ```
+
+  @ sections.motivation {
+    header = markdown`Motivation`
+    body = ```markdown
+    The key motivations for eure-mark are:
+
+    - **Type-safe frontmatter**: Validate metadata with schemas
+    - **Explicit hierarchy**: No guessing about section nesting
+    - **Integrated citations**: BibTeX support built-in!cite[knuth1984]
+    - **Structured footnotes**: First-class footnote definitions
+    ```
+  }
+
+  @ sections.goals {
+    header = markdown`Design Goals`
+    body = ```markdown
+    1. Maintain Markdown familiarity for content
+    2. Add structure where Markdown is weak
+    3. Enable programmatic document manipulation
+    4. Support academic/technical writing workflows
+    ```
+  }
+}
+
+@ sections.syntax {
+  header = markdown`Syntax Overview`
+  body = ```markdown
+  Eure-mark uses Eure syntax for structure and Markdown for content.
+  ```
+
+  @ sections.inline {
+    header = markdown`Inline Markdown`
+    body = ````markdown
+    For short text like headers, use inline code with `markdown` tag:
+
+    ```eure
+    header = markdown`Section *Title* with **emphasis**`
+    ```
+
+    This keeps headers on a single line while supporting basic formatting!footnote[see-spec].
+    ````
+  }
+
+  @ sections.block {
+    header = markdown`Block Markdown`
+    body = ````markdown
+    For longer content, use fenced code blocks:
+
+    ```eure
+    body = ```markdown
+    Multiple paragraphs of content...
+
+    - With lists
+    - And other block elements
+    ```
+    ```
+    ````
+  }
+}
+
+@ sections.references {
+  header = markdown`References`
+  body = ```markdown
+  This format was inspired by literate programming!cite[knuth1984] and
+  the LaTeX document preparation system!cite[lamport1994].
+  ```
+}

--- a/assets/examples/example.eumd
+++ b/assets/examples/example.eumd
@@ -45,8 +45,8 @@ cites = ```bibtex
   content = markdown`See the [CommonMark Spec](https://commonmark.org) for details.`
 }
 
-@ sections.intro {
-  header = markdown`Introduction`
+// Section key as header (no explicit header field needed)
+@ sections.Introduction {
   body = ```markdown
   Traditional Markdown documents have **implicit structure** based on heading levels.
   This can lead to ambiguity and makes programmatic manipulation difficult.
@@ -54,8 +54,7 @@ cites = ```bibtex
   Eure-mark addresses this by making the section hierarchy **explicit**!footnote[impl-detail].
   ```
 
-  @ sections.motivation {
-    header = markdown`Motivation`
+  @ sections.Motivation {
     body = ```markdown
     The key motivations for eure-mark are:
 
@@ -66,8 +65,8 @@ cites = ```bibtex
     ```
   }
 
-  @ sections.goals {
-    header = markdown`Design Goals`
+  // Quoted key for markdown formatting in header
+  @ sections."Design *Goals*" {
     body = ```markdown
     1. Maintain Markdown familiarity for content
     2. Add structure where Markdown is weak
@@ -77,14 +76,14 @@ cites = ```bibtex
   }
 }
 
+// Explicit header when key differs from display text
 @ sections.syntax {
   header = markdown`Syntax Overview`
   body = ```markdown
   Eure-mark uses Eure syntax for structure and Markdown for content.
   ```
 
-  @ sections.inline {
-    header = markdown`Inline Markdown`
+  @ sections."Inline Markdown" {
     body = ````markdown
     For short text like headers, use inline code with `markdown` tag:
 
@@ -96,8 +95,7 @@ cites = ```bibtex
     ````
   }
 
-  @ sections.block {
-    header = markdown`Block Markdown`
+  @ sections."Block Markdown" {
     body = ````markdown
     For longer content, use fenced code blocks:
 
@@ -113,8 +111,7 @@ cites = ```bibtex
   }
 }
 
-@ sections.references {
-  header = markdown`References`
+@ sections.References {
   body = ```markdown
   This format was inspired by literate programming!cite[knuth1984] and
   the LaTeX document preparation system!cite[lamport1994].

--- a/assets/schemas/eure-md.schema.eure
+++ b/assets/schemas/eure-md.schema.eure
@@ -1,0 +1,142 @@
+/// Eure Markdown Schema
+///
+/// A structured document format combining Eure's data model with Markdown content.
+/// File extension: .eumd
+///
+/// Key features:
+/// - Structured frontmatter with type-safe fields
+/// - Explicit section hierarchy (no implicit # heading parsing)
+/// - Integrated footnotes and citations (BibTeX)
+/// - Markdown content in code blocks
+///
+/// Section references:
+/// - Sections use map structure with ID as key: @ sections.intro { ... }
+/// - Reference in markdown: !ref[intro]
+/// - Nested sections: @ sections.intro.sections.subsection { ... }
+
+$schema = "eure-schema.schema.eure"
+$variant: record
+
+// ============================================================================
+// Document Root Fields
+// ============================================================================
+
+// ---- Frontmatter (metadata) ----
+
+/// Document title (inline markdown for formatting)
+title = `$types.inline-markdown`
+
+/// Document authors
+authors = [`$types.author`]
+authors.$optional = true
+
+/// Publication/creation date
+date = `text.date`
+date.$optional = true
+
+/// Categorization tags
+tags = [`text`]
+tags.$optional = true
+
+/// Draft status (unpublished if true)
+draft = `boolean`
+draft.$optional = true
+
+/// Document description/abstract
+description = `$types.block-markdown`
+description.$optional = true
+
+// ---- References ----
+
+/// Bibliography in BibTeX format
+cites = `$types.bibtex`
+cites.$optional = true
+
+// ---- Footnotes ----
+
+/// Footnote definitions (referenced in body via !footnote[key])
+footnotes {
+  $variant: map
+  key = `text`
+  value = `$types.footnote`
+}
+footnotes.$optional = true
+footnotes.$binding-style = "section"
+
+// ---- Document Body ----
+
+/// Introduction/preamble before first section
+intro = `$types.block-markdown`
+intro.$optional = true
+
+/// Document sections (map with ID as key for easy referencing)
+sections {
+  $variant: map
+  key = `text`
+  value = `$types.section`
+}
+sections.$optional = true
+sections.$binding-style = "section"
+
+// ============================================================================
+// Custom Types
+// ============================================================================
+
+/// Inline markdown text (for headers, short content)
+@ $types.inline-markdown {
+  $variant: text
+  language = "markdown"
+}
+
+/// Block markdown content (for body text)
+@ $types.block-markdown {
+  $variant: text
+  language = "markdown"
+}
+
+/// BibTeX bibliography content
+@ $types.bibtex {
+  $variant: text
+  language = "bibtex"
+}
+
+/// Author information
+@ $types.author {
+  $variant: union
+  // Simple: just a name string
+  variants.simple = `text`
+  // Detailed: name with affiliation, email, etc.
+  @ variants.detailed {
+    name = `text`
+    affiliation = `text`
+    affiliation.$optional = true
+    email = `text.email`
+    email.$optional = true
+    url = `text.url`
+    url.$optional = true
+  }
+}
+
+/// Footnote definition
+@ $types.footnote {
+  content = `$types.inline-markdown`
+}
+
+/// Section structure (recursive, map-based for referencing)
+@ $types.section {
+  // Section header (inline markdown)
+  header = `$types.inline-markdown`
+
+  // Section body content (block markdown)
+  body = `$types.block-markdown`
+  body.$optional = true
+
+  // Nested subsections (map with ID as key)
+  sections {
+    $variant: map
+    key = `text`
+    value = `$types.section`
+  }
+  sections.$optional = true
+  sections.$binding-style = "section"
+}

--- a/assets/schemas/eure-md.schema.eure
+++ b/assets/schemas/eure-md.schema.eure
@@ -9,9 +9,14 @@
 /// - Integrated footnotes and citations (BibTeX)
 /// - Markdown content in code blocks
 ///
-/// Section references:
-/// - Sections use map structure with ID as key: @ sections.intro { ... }
-/// - Reference in markdown: !ref[intro]
+/// Section keys as headers:
+/// - Section key is used as header if `header` field is omitted
+/// - @ sections.Introduction { body = ... }  → header is "Introduction"
+/// - @ sections."*euremark* について" { ... } → header with markdown formatting
+/// - @ sections.intro { header = markdown`Custom Header` } → explicit header
+///
+/// References:
+/// - Reference sections in markdown: !ref[intro]
 /// - Nested sections: @ sections.intro.sections.subsection { ... }
 
 $schema = "eure-schema.schema.eure"
@@ -123,9 +128,11 @@ sections.$binding-style = "section"
 }
 
 /// Section structure (recursive, map-based for referencing)
+/// If header is omitted, the section key is used as the header text.
 @ $types.section {
-  // Section header (inline markdown)
+  // Section header (inline markdown). If omitted, section key is used as header.
   header = `$types.inline-markdown`
+  header.$optional = true
 
   // Section body content (block markdown)
   body = `$types.block-markdown`


### PR DESCRIPTION
Introduces eure-mark (.eumd), a document format that combines Eure's
structured data model with Markdown content:

- eure-md.schema.eure: Schema defining document structure with
  frontmatter, sections (map-based for easy referencing), footnotes,
  and BibTeX citations
- example.eumd: Sample document demonstrating the format
- Eure.eure: Add eumd target for validation
- .gitignore: Track .eumd files