### PR TITLE
Replace manual ParseDocument implementations with derive macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1561,6 +1561,7 @@ version = "0.0.0"
 dependencies = [
  "bon",
  "eure-document",
+ "eure-macros",
 ]
 
 [[package]]

--- a/crates/eure-codegen/Cargo.toml
+++ b/crates/eure-codegen/Cargo.toml
@@ -12,3 +12,4 @@ keywords = ["codegen", "eure", "schema"]
 [dependencies]
 bon = "3"
 eure-document = { path = "../eure-document" }
+eure-macros = { workspace = true }

--- a/crates/eure-codegen/src/parse.rs
+++ b/crates/eure-codegen/src/parse.rs
@@ -11,7 +11,7 @@
 //! - [`RecordCodegen`] - Codegen settings for record types
 //! - [`FieldCodegen`] - Codegen settings for individual record fields
 
-use eure_document::parse::{ParseContext, ParseDocument, ParseError};
+use eure_macros::ParseDocument;
 
 // ============================================================================
 // Root-Level Codegen Types
@@ -29,23 +29,12 @@ use eure_document::parse::{ParseContext, ParseDocument, ParseError};
 ///   type = "MyRootType"
 /// }
 /// ```
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, ParseDocument)]
+#[eure(crate = eure_document)]
 pub struct RootCodegen {
     /// The root type name for the generated code.
+    #[eure(rename = "type", default)]
     pub type_name: Option<String>,
-}
-
-impl ParseDocument<'_> for RootCodegen {
-    type Error = ParseError;
-    fn parse(ctx: &ParseContext<'_>) -> Result<Self, Self::Error> {
-        let rec = ctx.parse_record()?;
-
-        let type_name = rec.parse_field_optional::<String>("type")?;
-
-        rec.deny_unknown_fields()?;
-
-        Ok(RootCodegen { type_name })
-    }
 }
 
 /// Default codegen settings applied to all types.
@@ -63,39 +52,21 @@ impl ParseDocument<'_> for RootCodegen {
 ///   document-node-id-field = "doc_node"
 /// }
 /// ```
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, ParseDocument)]
+#[eure(crate = eure_document, rename_all = "kebab-case")]
 pub struct CodegenDefaults {
     /// Default derive macros for all generated types.
+    #[eure(default)]
     pub derive: Option<Vec<String>>,
     /// Prefix for extension type field names (e.g., "ext_" -> ext_types).
+    #[eure(default)]
     pub ext_types_field_prefix: Option<String>,
     /// Prefix for extension type names (e.g., "Ext" -> ExtTypes).
+    #[eure(default)]
     pub ext_types_type_prefix: Option<String>,
     /// Field name for storing document node ID in generated types.
+    #[eure(default)]
     pub document_node_id_field: Option<String>,
-}
-
-impl ParseDocument<'_> for CodegenDefaults {
-    type Error = ParseError;
-    fn parse(ctx: &ParseContext<'_>) -> Result<Self, Self::Error> {
-        let rec = ctx.parse_record()?;
-
-        let derive = rec.parse_field_optional::<Vec<String>>("derive")?;
-        let ext_types_field_prefix =
-            rec.parse_field_optional::<String>("ext-types-field-prefix")?;
-        let ext_types_type_prefix = rec.parse_field_optional::<String>("ext-types-type-prefix")?;
-        let document_node_id_field =
-            rec.parse_field_optional::<String>("document-node-id-field")?;
-
-        rec.deny_unknown_fields()?;
-
-        Ok(CodegenDefaults {
-            derive,
-            ext_types_field_prefix,
-            ext_types_type_prefix,
-            document_node_id_field,
-        })
-    }
 }
 
 // ============================================================================
@@ -122,40 +93,21 @@ impl ParseDocument<'_> for CodegenDefaults {
 ///   variants.b = `integer`
 /// }
 /// ```
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, ParseDocument)]
+#[eure(crate = eure_document, rename_all = "kebab-case")]
 pub struct UnionCodegen {
     /// Override the generated type name (from base-codegen).
+    #[eure(rename = "type", default)]
     pub type_name: Option<String>,
     /// Override the list of derive macros (from base-codegen).
+    #[eure(default)]
     pub derive: Option<Vec<String>>,
     /// Generate separate types for each variant instead of struct-like variants.
+    #[eure(default)]
     pub variant_types: Option<bool>,
     /// Suffix for variant type names (e.g., "Type" -> TextType, IntegerType).
+    #[eure(default)]
     pub variant_types_suffix: Option<String>,
-}
-
-impl ParseDocument<'_> for UnionCodegen {
-    type Error = ParseError;
-    fn parse(ctx: &ParseContext<'_>) -> Result<Self, Self::Error> {
-        let rec = ctx.parse_record()?;
-
-        // Parse base-codegen fields (flattened)
-        let type_name = rec.parse_field_optional::<String>("type")?;
-        let derive = rec.parse_field_optional::<Vec<String>>("derive")?;
-
-        // Parse union-specific fields
-        let variant_types = rec.parse_field_optional::<bool>("variant-types")?;
-        let variant_types_suffix = rec.parse_field_optional::<String>("variant-types-suffix")?;
-
-        rec.deny_unknown_fields()?;
-
-        Ok(UnionCodegen {
-            type_name,
-            derive,
-            variant_types,
-            variant_types_suffix,
-        })
-    }
 }
 
 /// Codegen settings for record types.
@@ -179,27 +131,15 @@ impl ParseDocument<'_> for UnionCodegen {
 ///   age = `integer`
 /// }
 /// ```
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, ParseDocument)]
+#[eure(crate = eure_document)]
 pub struct RecordCodegen {
     /// Override the generated type name (from base-codegen).
+    #[eure(rename = "type", default)]
     pub type_name: Option<String>,
     /// Override the list of derive macros (from base-codegen).
+    #[eure(default)]
     pub derive: Option<Vec<String>>,
-}
-
-impl ParseDocument<'_> for RecordCodegen {
-    type Error = ParseError;
-    fn parse(ctx: &ParseContext<'_>) -> Result<Self, Self::Error> {
-        let rec = ctx.parse_record()?;
-
-        // Parse base-codegen fields (flattened)
-        let type_name = rec.parse_field_optional::<String>("type")?;
-        let derive = rec.parse_field_optional::<Vec<String>>("derive")?;
-
-        rec.deny_unknown_fields()?;
-
-        Ok(RecordCodegen { type_name, derive })
-    }
 }
 
 /// Codegen settings for individual record fields.
@@ -215,23 +155,12 @@ impl ParseDocument<'_> for RecordCodegen {
 ///   user-name.$codegen.name = "username"  // Rename to `username` in Rust
 /// }
 /// ```
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, ParseDocument)]
+#[eure(crate = eure_document)]
 pub struct FieldCodegen {
     /// Override the field name in generated Rust code.
+    #[eure(default)]
     pub name: Option<String>,
-}
-
-impl ParseDocument<'_> for FieldCodegen {
-    type Error = ParseError;
-    fn parse(ctx: &ParseContext<'_>) -> Result<Self, Self::Error> {
-        let rec = ctx.parse_record()?;
-
-        let name = rec.parse_field_optional::<String>("name")?;
-
-        rec.deny_unknown_fields()?;
-
-        Ok(FieldCodegen { name })
-    }
 }
 
 #[cfg(test)]

--- a/crates/eure-document/src/parse.rs
+++ b/crates/eure-document/src/parse.rs
@@ -1338,6 +1338,21 @@ where
     }
 }
 
+impl ParseDocument<'_> for regex::Regex {
+    type Error = ParseError;
+
+    fn parse(ctx: &ParseContext<'_>) -> Result<Self, Self::Error> {
+        let pattern: &str = ctx.parse()?;
+        regex::Regex::new(pattern).map_err(|e| ParseError {
+            node_id: ctx.node_id(),
+            kind: ParseErrorKind::InvalidPattern {
+                pattern: pattern.to_string(),
+                value: e.to_string(),
+            },
+        })
+    }
+}
+
 /// `Option<T>` is a union with variants `some` and `none`.
 ///
 /// - `$variant: some` -> parse T

--- a/crates/eure-document/src/parse.rs
+++ b/crates/eure-document/src/parse.rs
@@ -830,9 +830,13 @@ pub enum ParseErrorKind {
     #[error("value out of range: {0}")]
     OutOfRange(String),
 
-    /// Invalid string pattern.
-    #[error("invalid pattern: expected {pattern}, got {value}")]
-    InvalidPattern { pattern: String, value: String },
+    /// Invalid value pattern or format.
+    ///
+    /// Used for validation errors in types like regex, URL, UUID, etc.
+    /// - `kind`: Type of validation (e.g., "regex", "url", "uuid", "pattern: <expected>")
+    /// - `reason`: Human-readable error message explaining the failure
+    #[error("invalid {kind}: {reason}")]
+    InvalidPattern { kind: String, reason: String },
 
     /// Nested parse error with path context.
     #[error("at {path}: {source}")]
@@ -1346,8 +1350,8 @@ impl ParseDocument<'_> for regex::Regex {
         regex::Regex::new(pattern).map_err(|e| ParseError {
             node_id: ctx.node_id(),
             kind: ParseErrorKind::InvalidPattern {
-                pattern: pattern.to_string(),
-                value: e.to_string(),
+                kind: format!("regex '{}'", pattern),
+                reason: e.to_string(),
             },
         })
     }

--- a/crates/eure-macros/src/attrs/container.rs
+++ b/crates/eure-macros/src/attrs/container.rs
@@ -16,4 +16,8 @@ pub struct ContainerAttrs {
     /// When true, uses `ctx.parse_extension()` and `ext.parse_ext()` instead of
     /// `ctx.parse_record()` and `rec.parse_field()`.
     pub parse_ext: bool,
+    /// Allow unknown fields instead of denying them.
+    /// By default (false), unknown fields cause a parse error.
+    /// When true, uses `allow_unknown_fields()` instead of `deny_unknown_fields()`.
+    pub allow_unknown_fields: bool,
 }

--- a/crates/eure-macros/src/attrs/container.rs
+++ b/crates/eure-macros/src/attrs/container.rs
@@ -20,4 +20,8 @@ pub struct ContainerAttrs {
     /// By default (false), unknown fields cause a parse error.
     /// When true, uses `allow_unknown_fields()` instead of `deny_unknown_fields()`.
     pub allow_unknown_fields: bool,
+    /// Allow unknown extensions instead of denying them.
+    /// By default (false), unknown extensions cause a parse error.
+    /// When true, skips the `deny_unknown_extensions()` check.
+    pub allow_unknown_extensions: bool,
 }

--- a/crates/eure-macros/src/attrs/variant.rs
+++ b/crates/eure-macros/src/attrs/variant.rs
@@ -5,4 +5,8 @@ use darling::FromVariant;
 pub struct VariantAttrs {
     /// Explicit rename for this variant (overrides rename_all)
     pub rename: Option<String>,
+    /// Allow unknown fields for this variant instead of denying them.
+    /// By default (false), unknown fields cause a parse error.
+    /// When true, uses `allow_unknown_fields()` instead of `deny_unknown_fields()`.
+    pub allow_unknown_fields: bool,
 }

--- a/crates/eure-macros/src/config.rs
+++ b/crates/eure-macros/src/config.rs
@@ -9,6 +9,8 @@ pub struct MacroConfig {
     pub rename_all_fields: Option<RenameAll>,
     /// Parse fields from extension namespace instead of record fields.
     pub parse_ext: bool,
+    /// Allow unknown fields instead of denying them.
+    pub allow_unknown_fields: bool,
 }
 
 impl MacroConfig {
@@ -23,6 +25,7 @@ impl MacroConfig {
             rename_all: attrs.rename_all,
             rename_all_fields: attrs.rename_all_fields,
             parse_ext: attrs.parse_ext,
+            allow_unknown_fields: attrs.allow_unknown_fields,
         }
     }
 }

--- a/crates/eure-macros/src/config.rs
+++ b/crates/eure-macros/src/config.rs
@@ -11,6 +11,8 @@ pub struct MacroConfig {
     pub parse_ext: bool,
     /// Allow unknown fields instead of denying them.
     pub allow_unknown_fields: bool,
+    /// Allow unknown extensions instead of denying them.
+    pub allow_unknown_extensions: bool,
 }
 
 impl MacroConfig {
@@ -26,6 +28,7 @@ impl MacroConfig {
             rename_all_fields: attrs.rename_all_fields,
             parse_ext: attrs.parse_ext,
             allow_unknown_fields: attrs.allow_unknown_fields,
+            allow_unknown_extensions: attrs.allow_unknown_extensions,
         }
     }
 }

--- a/crates/eure-macros/src/parse_document/parse_record.rs
+++ b/crates/eure-macros/src/parse_document/parse_record.rs
@@ -93,12 +93,18 @@ fn generate_named_struct_from_record(
         })
         .collect();
 
+    let unknown_fields_check = if context.config.allow_unknown_fields {
+        quote! { rec.allow_unknown_fields()?; }
+    } else {
+        quote! { rec.deny_unknown_fields()?; }
+    };
+
     context.impl_parse_document(quote! {
         let rec = ctx.parse_record()?;
         let value = #ident {
             #(#field_assignments),*
         };
-        rec.deny_unknown_fields()?;
+        #unknown_fields_check
         ctx.deny_unknown_extensions()?;
         Ok(value)
     })

--- a/crates/eure-macros/src/parse_document/parse_record.rs
+++ b/crates/eure-macros/src/parse_document/parse_record.rs
@@ -99,13 +99,19 @@ fn generate_named_struct_from_record(
         quote! { rec.deny_unknown_fields()?; }
     };
 
+    let unknown_extensions_check = if context.config.allow_unknown_extensions {
+        quote! {}
+    } else {
+        quote! { ctx.deny_unknown_extensions()?; }
+    };
+
     context.impl_parse_document(quote! {
         let rec = ctx.parse_record()?;
         let value = #ident {
             #(#field_assignments),*
         };
         #unknown_fields_check
-        ctx.deny_unknown_extensions()?;
+        #unknown_extensions_check
         Ok(value)
     })
 }

--- a/crates/eure-macros/tests/records/allow_unknown_fields.rs
+++ b/crates/eure-macros/tests/records/allow_unknown_fields.rs
@@ -1,0 +1,72 @@
+use eure::ParseDocument;
+
+// Struct that allows unknown fields
+#[derive(Debug, PartialEq, ParseDocument)]
+#[eure(crate = ::eure::document, allow_unknown_fields)]
+struct ConfigWithUnknown {
+    name: String,
+    version: i32,
+}
+
+// Default behavior: deny unknown fields
+#[derive(Debug, PartialEq, ParseDocument)]
+#[eure(crate = ::eure::document)]
+struct ConfigStrict {
+    name: String,
+    version: i32,
+}
+
+#[test]
+fn test_allow_unknown_fields_accepts_extra() {
+    use eure::eure;
+    let doc = eure!({
+        name = "test",
+        version = 1,
+        extra_field = "ignored",
+        another_extra = 42
+    });
+
+    let result = doc.parse::<ConfigWithUnknown>(doc.get_root_id());
+    assert_eq!(
+        result.unwrap(),
+        ConfigWithUnknown {
+            name: "test".to_string(),
+            version: 1,
+        }
+    );
+}
+
+#[test]
+fn test_allow_unknown_fields_works_without_extra() {
+    use eure::eure;
+    let doc = eure!({
+        name = "test",
+        version = 1
+    });
+
+    let result = doc.parse::<ConfigWithUnknown>(doc.get_root_id());
+    assert_eq!(
+        result.unwrap(),
+        ConfigWithUnknown {
+            name: "test".to_string(),
+            version: 1,
+        }
+    );
+}
+
+#[test]
+fn test_default_deny_unknown_fields() {
+    use eure::eure;
+    use eure::document::parse::ParseErrorKind;
+    let doc = eure!({
+        name = "test",
+        version = 1,
+        extra_field = "should fail"
+    });
+
+    let result = doc.parse::<ConfigStrict>(doc.get_root_id());
+    assert!(matches!(
+        result.unwrap_err().kind,
+        ParseErrorKind::UnknownField(_)
+    ));
+}

--- a/crates/eure-macros/tests/unions/allow_unknown_fields.rs
+++ b/crates/eure-macros/tests/unions/allow_unknown_fields.rs
@@ -1,0 +1,49 @@
+use eure::ParseDocument;
+
+// Enum with variant that allows unknown fields
+#[derive(Debug, PartialEq, ParseDocument)]
+#[eure(crate = ::eure::document)]
+enum Message {
+    Text(String),
+    #[eure(allow_unknown_fields)]
+    Data { id: i32, value: String },
+    Strict { id: i32, value: String },
+}
+
+#[test]
+fn test_variant_allow_unknown_fields_accepts_extra() {
+    use eure::eure;
+    let doc = eure!({
+        %variant = "Data",
+        id = 1,
+        value = "test",
+        extra = "ignored"
+    });
+
+    let result = doc.parse::<Message>(doc.get_root_id());
+    assert_eq!(
+        result.unwrap(),
+        Message::Data {
+            id: 1,
+            value: "test".to_string(),
+        }
+    );
+}
+
+#[test]
+fn test_variant_default_deny_unknown_fields() {
+    use eure::eure;
+    use eure::document::parse::ParseErrorKind;
+    let doc = eure!({
+        %variant = "Strict",
+        id = 1,
+        value = "test",
+        extra = "should fail"
+    });
+
+    let result = doc.parse::<Message>(doc.get_root_id());
+    assert!(matches!(
+        result.unwrap_err().kind,
+        ParseErrorKind::UnknownField(_)
+    ));
+}

--- a/crates/eure-schema/src/convert.rs
+++ b/crates/eure-schema/src/convert.rs
@@ -45,12 +45,13 @@
 use crate::parse::{
     ParsedArraySchema, ParsedExtTypeSchema, ParsedFloatSchema, ParsedIntegerSchema,
     ParsedMapSchema, ParsedRecordSchema, ParsedSchemaMetadata, ParsedSchemaNode,
-    ParsedSchemaNodeContent, ParsedTupleSchema, ParsedUnionSchema, ParsedUnknownFieldsPolicy,
+    ParsedSchemaNodeContent, ParsedTextSchema, ParsedTupleSchema, ParsedUnionSchema,
+    ParsedUnknownFieldsPolicy,
 };
 use crate::{
     ArraySchema, Bound, ExtTypeSchema, FloatPrecision, FloatSchema, IntegerSchema, MapSchema,
     RecordFieldSchema, RecordSchema, SchemaDocument, SchemaMetadata, SchemaNodeContent,
-    SchemaNodeId, TupleSchema, UnionSchema, UnknownFieldsPolicy,
+    SchemaNodeId, TextSchema, TupleSchema, UnionSchema, UnknownFieldsPolicy,
 };
 use eure_document::document::node::{Node, NodeValue};
 use eure_document::document::{EureDocument, NodeId};
@@ -58,6 +59,7 @@ use eure_document::identifier::Identifier;
 use eure_document::parse::ParseError;
 use eure_document::value::ObjectKey;
 use num_bigint::BigInt;
+use regex::Regex;
 use std::collections::{BTreeMap, HashMap};
 use thiserror::Error;
 
@@ -78,6 +80,9 @@ pub enum ConversionError {
 
     #[error("Invalid precision: {0} (expected \"f32\" or \"f64\")")]
     InvalidPrecision(String),
+
+    #[error("Invalid regex pattern '{pattern}': {error}")]
+    InvalidRegexPattern { pattern: String, error: String },
 
     #[error("Undefined type reference: {0}")]
     UndefinedTypeReference(String),
@@ -195,7 +200,9 @@ impl<'a> Converter<'a> {
             ParsedSchemaNodeContent::Any => Ok(SchemaNodeContent::Any),
             ParsedSchemaNodeContent::Boolean => Ok(SchemaNodeContent::Boolean),
             ParsedSchemaNodeContent::Null => Ok(SchemaNodeContent::Null),
-            ParsedSchemaNodeContent::Text(schema) => Ok(SchemaNodeContent::Text(schema)),
+            ParsedSchemaNodeContent::Text(parsed) => {
+                Ok(SchemaNodeContent::Text(Self::convert_text_schema(parsed)?))
+            }
             ParsedSchemaNodeContent::Reference(type_ref) => {
                 Ok(SchemaNodeContent::Reference(type_ref))
             }
@@ -225,6 +232,27 @@ impl<'a> Converter<'a> {
                 Ok(SchemaNodeContent::Union(self.convert_union_schema(parsed)?))
             }
         }
+    }
+
+    /// Convert parsed text schema to final text schema (compiles regex pattern)
+    fn convert_text_schema(parsed: ParsedTextSchema) -> Result<TextSchema, ConversionError> {
+        let pattern = match &parsed.pattern {
+            Some(s) => Some(
+                Regex::new(s).map_err(|e| ConversionError::InvalidRegexPattern {
+                    pattern: s.clone(),
+                    error: e.to_string(),
+                })?,
+            ),
+            None => None,
+        };
+
+        Ok(TextSchema {
+            language: parsed.language,
+            min_length: parsed.min_length,
+            max_length: parsed.max_length,
+            pattern,
+            unknown_fields: parsed.unknown_fields,
+        })
     }
 
     /// Convert parsed integer schema (with range string) to final integer schema (with Bound)

--- a/crates/eure-schema/src/lib.rs
+++ b/crates/eure-schema/src/lib.rs
@@ -477,7 +477,8 @@ pub struct TypeReference {
 /// ```eure
 /// description => { $variant: union, variants.string => .text, variants.markdown => .text.markdown }
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ParseDocument)]
+#[eure(crate = eure_document, rename_all = "lowercase")]
 pub enum Description {
     /// Plain text description
     String(String),

--- a/crates/eure-schema/src/lib.rs
+++ b/crates/eure-schema/src/lib.rs
@@ -199,7 +199,8 @@ pub enum Bound<T> {
 /// max-length = .integer (optional)
 /// pattern = .text (optional)
 /// ```
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, ParseDocument)]
+#[eure(crate = eure_document, rename_all = "kebab-case", allow_unknown_fields, allow_unknown_extensions)]
 pub struct TextSchema {
     /// Language identifier (e.g., "rust", "javascript", "email", "plaintext")
     ///
@@ -208,15 +209,20 @@ pub struct TextSchema {
     ///
     /// Note: When a value has `Language::Implicit` (from `` `...` `` syntax),
     /// it can be coerced to match the schema's expected language.
+    #[eure(default)]
     pub language: Option<String>,
     /// Minimum length constraint (in UTF-8 code points)
+    #[eure(default)]
     pub min_length: Option<u32>,
     /// Maximum length constraint (in UTF-8 code points)
+    #[eure(default)]
     pub max_length: Option<u32>,
     /// Regex pattern constraint (applied to the text content).
     /// Pre-compiled at schema parse time for efficiency.
+    #[eure(default)]
     pub pattern: Option<Regex>,
     /// Unknown fields (for future extensions like "flatten")
+    #[eure(flatten)]
     pub unknown_fields: std::collections::HashMap<String, eure_document::document::NodeId>,
 }
 

--- a/crates/eure-schema/src/parse.rs
+++ b/crates/eure-schema/src/parse.rs
@@ -40,8 +40,11 @@ impl ParseDocument<'_> for TypeReference {
         let path = path.strip_prefix("$types.").ok_or_else(|| ParseError {
             node_id: ctx.node_id(),
             kind: ParseErrorKind::InvalidPattern {
-                pattern: "$types.<name> or $types.<namespace>.<name>".to_string(),
-                value: path.to_string(),
+                kind: "type reference".to_string(),
+                reason: format!(
+                    "expected '$types.<name>' or '$types.<namespace>.<name>', got '{}'",
+                    path
+                ),
             },
         })?;
 
@@ -71,8 +74,11 @@ impl ParseDocument<'_> for TypeReference {
             _ => Err(ParseError {
                 node_id: ctx.node_id(),
                 kind: ParseErrorKind::InvalidPattern {
-                    pattern: "$types.<name> or $types.<namespace>.<name>".to_string(),
-                    value: format!("$types.{}", path),
+                    kind: "type reference".to_string(),
+                    reason: format!(
+                        "expected '$types.<name>' or '$types.<namespace>.<name>', got '$types.{}'",
+                        path
+                    ),
                 },
             }),
         }
@@ -617,8 +623,8 @@ fn parse_type_reference_string(
         return Err(ParseError {
             node_id,
             kind: ParseErrorKind::InvalidPattern {
-                pattern: "non-empty type reference".to_string(),
-                value: String::new(),
+                kind: "type reference".to_string(),
+                reason: "expected non-empty type reference, got empty string".to_string(),
             },
         });
     }
@@ -676,8 +682,11 @@ fn parse_type_reference_string(
         _ => Err(ParseError {
             node_id,
             kind: ParseErrorKind::InvalidPattern {
-                pattern: "type reference (e.g., 'text', 'integer', '$types.name')".to_string(),
-                value: s.to_string(),
+                kind: "type reference".to_string(),
+                reason: format!(
+                    "expected 'text', 'integer', '$types.name', etc., got '{}'",
+                    s
+                ),
             },
         }),
     }
@@ -769,8 +778,11 @@ impl ParseDocument<'_> for ParsedSchemaNodeContent {
                     Err(ParseError {
                         node_id,
                         kind: ParseErrorKind::InvalidPattern {
-                            pattern: "single-element array for array schema shorthand".to_string(),
-                            value: format!("{}-element array", arr.len()),
+                            kind: "array schema shorthand".to_string(),
+                            reason: format!(
+                                "expected single-element array [type], got {}-element array",
+                                arr.len()
+                            ),
                         },
                     })
                 }

--- a/crates/eure-schema/src/parse.rs
+++ b/crates/eure-schema/src/parse.rs
@@ -23,24 +23,11 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use eure_document::data_model::VariantRepr;
 use eure_document::document::NodeId;
 use eure_document::identifier::Identifier;
-use eure_document::parse::{
-    DocumentParserExt as _, ParseContext, ParseDocument, ParseError, ParseErrorKind,
-};
+use eure_document::parse::{ParseContext, ParseDocument, ParseError, ParseErrorKind};
 use num_bigint::BigInt;
 use regex::Regex;
 
 use crate::{BindingStyle, Description, TextSchema, TypeReference};
-
-impl ParseDocument<'_> for Description {
-    type Error = ParseError;
-    fn parse(ctx: &ParseContext<'_>) -> Result<Self, Self::Error> {
-        use eure_document::data_model::VariantRepr;
-        ctx.parse_union(VariantRepr::default())?
-            .variant("string", String::parse.map(Description::String))
-            .variant("markdown", String::parse.map(Description::Markdown))
-            .parse()
-    }
-}
 
 impl ParseDocument<'_> for TypeReference {
     type Error = ParseError;

--- a/test-suite/cases/schema/primitives.eure
+++ b/test-suite/cases/schema/primitives.eure
@@ -110,9 +110,9 @@ name = `texte`
 ```
 
 schema_conversion_error = ```
-error: Parse error: parse error: invalid pattern: expected type reference (e.g., 'text', 'integer', '$types.name'), got texte
+error: Parse error: parse error: invalid type reference: expected 'text', 'integer', '$types.name', etc., got 'texte'
  --> <schema>:1:1
   |
 1 | name = `texte`
-  | ^^^^^^^^^^^^^^ Parse error: parse error: invalid pattern: expected type reference (e.g., 'text', 'integer', '$types.name'), got texte
+  | ^^^^^^^^^^^^^^ Parse error: parse error: invalid type reference: expected 'text', 'integer', '$types.name', etc., got 'texte'
 ```


### PR DESCRIPTION
- Add #[eure(allow_unknown_fields)] container and variant attributes to eure-macros
- Replace manual ParseDocument implementations in eure-codegen (5 types):
  RootCodegen, CodegenDefaults, UnionCodegen, RecordCodegen, FieldCodegen
- Replace manual ParseDocument implementations in eure-config (3 types):
  Target, CliConfig, LsConfig
- Replace manual ParseDocument implementation in eure-schema:
  Description enum now uses derive with rename_all = "lowercase"
- Add tests for allow_unknown_fields attribute on both structs and enum variants