### PR TITLE
Add #[eure(parse_error = CustomError)] container attribute for ParseDocument derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1701,6 +1701,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+ "thiserror 2.0.17",
 ]
 
 [[package]]

--- a/crates/eure-macros/Cargo.toml
+++ b/crates/eure-macros/Cargo.toml
@@ -22,3 +22,4 @@ syn = { version = "2.0", features = ["extra-traits", "full"] }
 [dev-dependencies]
 automod = { workspace = true }
 eure = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/eure-macros/src/attrs/container.rs
+++ b/crates/eure-macros/src/attrs/container.rs
@@ -24,4 +24,8 @@ pub struct ContainerAttrs {
     /// By default (false), unknown extensions cause a parse error.
     /// When true, skips the `deny_unknown_extensions()` check.
     pub allow_unknown_extensions: bool,
+    /// Custom error type for the ParseDocument impl.
+    /// When specified, the generated `type Error` is set to this type instead of `ParseError`.
+    /// The custom error type must implement `From<ParseError>` for `?` to work.
+    pub parse_error: Option<Path>,
 }

--- a/crates/eure-macros/src/config.rs
+++ b/crates/eure-macros/src/config.rs
@@ -13,6 +13,8 @@ pub struct MacroConfig {
     pub allow_unknown_fields: bool,
     /// Allow unknown extensions instead of denying them.
     pub allow_unknown_extensions: bool,
+    /// Custom error type for the ParseDocument impl.
+    pub parse_error: Option<TokenStream>,
 }
 
 impl MacroConfig {
@@ -22,6 +24,7 @@ impl MacroConfig {
             .crate_path
             .map(|path| path.into_token_stream())
             .unwrap_or_else(|| quote! { ::eure::document });
+        let parse_error = attrs.parse_error.map(|path| path.into_token_stream());
         Self {
             document_crate,
             rename_all: attrs.rename_all,
@@ -29,6 +32,7 @@ impl MacroConfig {
             parse_ext: attrs.parse_ext,
             allow_unknown_fields: attrs.allow_unknown_fields,
             allow_unknown_extensions: attrs.allow_unknown_extensions,
+            parse_error,
         }
     }
 }

--- a/crates/eure-macros/src/context.rs
+++ b/crates/eure-macros/src/context.rs
@@ -92,8 +92,12 @@ impl MacroContext {
 
     #[allow(non_snake_case)]
     pub fn ParseError(&self) -> TokenStream {
-        let document_crate = &self.config.document_crate;
-        quote!(#document_crate::parse::ParseError)
+        if let Some(ref custom_error) = self.config.parse_error {
+            custom_error.clone()
+        } else {
+            let document_crate = &self.config.document_crate;
+            quote!(#document_crate::parse::ParseError)
+        }
     }
 
     #[allow(non_snake_case)]

--- a/crates/eure-macros/tests/records/custom_parse_error.rs
+++ b/crates/eure-macros/tests/records/custom_parse_error.rs
@@ -1,0 +1,162 @@
+use eure::document::parse::{ParseContext, ParseError, ParseErrorKind};
+use eure::ParseDocument;
+
+/// A custom inner error type that can be returned from manual ParseDocument implementations.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum InnerError {
+    #[error("parse error: {0}")]
+    Parse(#[from] ParseError),
+    #[error("validation error: {message}")]
+    Validation { message: String },
+}
+
+/// A custom error type that combines ParseError and InnerError.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum CustomError {
+    #[error("parse error: {0}")]
+    Parse(#[from] ParseError),
+    #[error("inner error: {0}")]
+    Inner(#[from] InnerError),
+}
+
+/// An inner struct that uses manual ParseDocument implementation
+/// that returns InnerError.
+#[derive(Debug, PartialEq)]
+pub struct InnerStruct {
+    pub value: i32,
+}
+
+impl<'doc> eure::document::parse::ParseDocument<'doc> for InnerStruct {
+    type Error = InnerError;
+
+    fn parse(ctx: &ParseContext<'doc>) -> Result<Self, Self::Error> {
+        let rec = ctx.parse_record()?;
+        let value: i32 = rec.parse_field("value")?;
+
+        // Demonstrate returning a custom InnerError based on validation
+        if value < 0 {
+            return Err(InnerError::Validation {
+                message: "value must be non-negative".to_string(),
+            });
+        }
+
+        rec.deny_unknown_fields()?;
+        Ok(InnerStruct { value })
+    }
+}
+
+/// An outer struct that uses the derive macro with custom error type.
+/// The derive macro will use CustomError as the error type instead of ParseError.
+/// Since CustomError implements From<InnerError>, the `?` operator will convert
+/// InnerError to CustomError automatically.
+#[derive(Debug, PartialEq, ParseDocument)]
+#[eure(crate = ::eure::document, parse_error = CustomError)]
+pub struct OuterStruct {
+    pub name: String,
+    pub inner: InnerStruct,
+}
+
+#[test]
+fn test_custom_error_success() {
+    use eure::eure;
+    let doc = eure!({
+        name = "test"
+        inner { value = 42 }
+    });
+    let result = doc.parse::<OuterStruct>(doc.get_root_id());
+    assert_eq!(
+        result.unwrap(),
+        OuterStruct {
+            name: "test".to_string(),
+            inner: InnerStruct { value: 42 }
+        }
+    );
+}
+
+#[test]
+fn test_custom_error_from_parse_error() {
+    use eure::eure;
+    // Missing required field "name"
+    let doc = eure!({
+        inner { value = 42 }
+    });
+    let result = doc.parse::<OuterStruct>(doc.get_root_id());
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    // Error should be converted from ParseError
+    match err {
+        CustomError::Parse(parse_err) => {
+            assert!(matches!(parse_err.kind, ParseErrorKind::MissingField(_)));
+        }
+        _ => panic!("expected CustomError::Parse, got {:?}", err),
+    }
+}
+
+#[test]
+fn test_custom_error_from_inner_error() {
+    use eure::eure;
+    // InnerStruct validation fails (negative value)
+    let doc = eure!({
+        name = "test"
+        inner { value = -1 }
+    });
+    let result = doc.parse::<OuterStruct>(doc.get_root_id());
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    // Error should be converted from InnerError via From<InnerError>
+    match err {
+        CustomError::Inner(InnerError::Validation { message }) => {
+            assert_eq!(message, "value must be non-negative");
+        }
+        _ => panic!("expected CustomError::Inner(InnerError::Validation), got {:?}", err),
+    }
+}
+
+/// A nested struct that contains another derived struct
+/// to test that nested types also work with custom errors.
+#[derive(Debug, PartialEq, ParseDocument)]
+#[eure(crate = ::eure::document, parse_error = CustomError)]
+pub struct NestedStruct {
+    pub outer: OuterStruct,
+}
+
+#[test]
+fn test_nested_custom_error() {
+    use eure::eure;
+    let doc = eure!({
+        outer {
+            name = "test"
+            inner { value = 10 }
+        }
+    });
+    let result = doc.parse::<NestedStruct>(doc.get_root_id());
+    assert_eq!(
+        result.unwrap(),
+        NestedStruct {
+            outer: OuterStruct {
+                name: "test".to_string(),
+                inner: InnerStruct { value: 10 }
+            }
+        }
+    );
+}
+
+#[test]
+fn test_nested_inner_error_bubbles_up() {
+    use eure::eure;
+    let doc = eure!({
+        outer {
+            name = "test"
+            inner { value = -5 }
+        }
+    });
+    let result = doc.parse::<NestedStruct>(doc.get_root_id());
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    match err {
+        CustomError::Inner(InnerError::Validation { message }) => {
+            assert_eq!(message, "value must be non-negative");
+        }
+        _ => panic!("expected CustomError::Inner(InnerError::Validation), got {:?}", err),
+    }
+}


### PR DESCRIPTION
Allows specifying a custom error type for the generated ParseDocument impl.
The custom error type is used instead of ParseError for `type Error`.
The custom type must implement `From<ParseError>` for `?` to work.

This enables:
- Combining multiple error sources with enum error types
- Adding custom validation errors from nested ParseDocument impls
- Using domain-specific error types throughout the parsing chain