### PR TITLE
Add BuildSchema trait and derive macro for generating EureSchema from Rust types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1699,6 +1699,8 @@ dependencies = [
  "convert_case 0.10.0",
  "darling 0.23.0",
  "eure",
+ "eure-document",
+ "eure-schema",
  "proc-macro2",
  "quote",
  "syn",

--- a/crates/eure-macros/Cargo.toml
+++ b/crates/eure-macros/Cargo.toml
@@ -22,4 +22,6 @@ syn = { version = "2.0", features = ["extra-traits", "full"] }
 [dev-dependencies]
 automod = { workspace = true }
 eure = { workspace = true }
+eure-document = { workspace = true }
+eure-schema = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/eure-macros/src/attrs/container.rs
+++ b/crates/eure-macros/src/attrs/container.rs
@@ -28,4 +28,8 @@ pub struct ContainerAttrs {
     /// When specified, the generated `type Error` is set to this type instead of `ParseError`.
     /// The custom error type must implement `From<ParseError>` for `?` to work.
     pub parse_error: Option<Path>,
+    /// Type name for BuildSchema registration in `$types` namespace.
+    /// When specified, the type is registered as `$types.<type_name>`.
+    /// Example: `#[eure(type_name = "user")]` registers as `$types.user`.
+    pub type_name: Option<String>,
 }

--- a/crates/eure-macros/src/build_schema.rs
+++ b/crates/eure-macros/src/build_schema.rs
@@ -1,0 +1,18 @@
+//! BuildSchema derive macro implementation
+
+mod build_record;
+mod build_union;
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::Data;
+
+use crate::context::MacroContext;
+
+pub fn derive(context: MacroContext) -> TokenStream {
+    match &context.input.data {
+        Data::Struct(data) => build_record::generate_record_schema(&context, data),
+        Data::Union(_) => quote! { compile_error!("Union is not supported for BuildSchema") },
+        Data::Enum(data) => build_union::generate_union_schema(&context, data),
+    }
+}

--- a/crates/eure-macros/src/build_schema/build_record.rs
+++ b/crates/eure-macros/src/build_schema/build_record.rs
@@ -1,0 +1,161 @@
+//! BuildSchema derive implementation for structs (records)
+
+use darling::FromField;
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{DataStruct, Fields};
+
+use crate::attrs::FieldAttrs;
+use crate::context::MacroContext;
+
+pub fn generate_record_schema(context: &MacroContext, input: &DataStruct) -> TokenStream {
+    match &input.fields {
+        Fields::Named(fields) => generate_named_struct(context, &fields.named),
+        Fields::Unnamed(fields) if fields.unnamed.len() == 1 => {
+            generate_newtype_struct(context, &fields.unnamed[0].ty)
+        }
+        Fields::Unnamed(fields) => generate_tuple_struct(context, &fields.unnamed),
+        Fields::Unit => generate_unit_struct(context),
+    }
+}
+
+fn generate_named_struct(
+    context: &MacroContext,
+    fields: &syn::punctuated::Punctuated<syn::Field, syn::token::Comma>,
+) -> TokenStream {
+    let schema_crate = context.schema_crate();
+
+    let field_schemas: Vec<_> = fields
+        .iter()
+        .enumerate()
+        .map(|(idx, f)| {
+            let field_name = f.ident.as_ref().expect("named fields must have names");
+            let field_ty = &f.ty;
+            let attrs = FieldAttrs::from_field(f).expect("failed to parse field attributes");
+
+            // Skip flatten fields for now - they need special handling
+            if attrs.flatten || attrs.flatten_ext {
+                panic!("flatten is not yet supported in BuildSchema derive");
+            }
+
+            let field_name_str = attrs
+                .rename
+                .clone()
+                .unwrap_or_else(|| context.apply_rename(&field_name.to_string()));
+
+            let schema_var = format_ident!("field_{}_schema", idx);
+
+            // Check if the field is Option<T> to mark as optional
+            let is_optional = is_option_type(field_ty);
+
+            (field_name_str, schema_var, field_ty.clone(), is_optional)
+        })
+        .collect();
+
+    // Generate schema building for each field
+    let field_builds: Vec<_> = field_schemas
+        .iter()
+        .map(|(_, schema_var, field_ty, _)| {
+            quote! {
+                let #schema_var = ctx.build::<#field_ty>();
+            }
+        })
+        .collect();
+
+    // Generate the properties HashMap entries
+    let properties_entries: Vec<_> = field_schemas
+        .iter()
+        .map(|(name, schema_var, _, is_optional)| {
+            quote! {
+                (
+                    #name.to_string(),
+                    #schema_crate::RecordFieldSchema {
+                        schema: #schema_var,
+                        optional: #is_optional,
+                        binding_style: None,
+                    }
+                )
+            }
+        })
+        .collect();
+
+    // Determine unknown fields policy
+    let unknown_fields_policy = if context.config.allow_unknown_fields {
+        quote! { #schema_crate::UnknownFieldsPolicy::Allow }
+    } else {
+        quote! { #schema_crate::UnknownFieldsPolicy::Deny }
+    };
+
+    let content = quote! {
+        #(#field_builds)*
+
+        #schema_crate::SchemaNodeContent::Record(#schema_crate::RecordSchema {
+            properties: [
+                #(#properties_entries),*
+            ].into_iter().collect(),
+            unknown_fields: #unknown_fields_policy,
+        })
+    };
+
+    context.impl_build_schema(content)
+}
+
+fn generate_unit_struct(context: &MacroContext) -> TokenStream {
+    let schema_crate = context.schema_crate();
+    let content = quote! {
+        #schema_crate::SchemaNodeContent::Null
+    };
+    context.impl_build_schema(content)
+}
+
+fn generate_tuple_struct(
+    context: &MacroContext,
+    fields: &syn::punctuated::Punctuated<syn::Field, syn::token::Comma>,
+) -> TokenStream {
+    let schema_crate = context.schema_crate();
+
+    let field_builds: Vec<_> = fields
+        .iter()
+        .enumerate()
+        .map(|(idx, f)| {
+            let field_ty = &f.ty;
+            let schema_var = format_ident!("field_{}_schema", idx);
+            quote! {
+                let #schema_var = ctx.build::<#field_ty>();
+            }
+        })
+        .collect();
+
+    let schema_vars: Vec<_> = (0..fields.len())
+        .map(|idx| format_ident!("field_{}_schema", idx))
+        .collect();
+
+    let content = quote! {
+        #(#field_builds)*
+
+        #schema_crate::SchemaNodeContent::Tuple(#schema_crate::TupleSchema {
+            elements: vec![#(#schema_vars),*],
+            binding_style: None,
+        })
+    };
+
+    context.impl_build_schema(content)
+}
+
+fn generate_newtype_struct(context: &MacroContext, field_ty: &syn::Type) -> TokenStream {
+    // Newtype just delegates to the inner type
+    let content = quote! {
+        <#field_ty as BuildSchema>::build_schema(ctx)
+    };
+    context.impl_build_schema(content)
+}
+
+/// Check if a type is Option<T>
+fn is_option_type(ty: &syn::Type) -> bool {
+    if let syn::Type::Path(type_path) = ty
+        && let Some(segment) = type_path.path.segments.last()
+    {
+        return segment.ident == "Option";
+    }
+    false
+}

--- a/crates/eure-macros/src/build_schema/build_union.rs
+++ b/crates/eure-macros/src/build_schema/build_union.rs
@@ -1,0 +1,171 @@
+//! BuildSchema derive implementation for enums (unions)
+
+use darling::FromField;
+use darling::FromVariant;
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::DataEnum;
+
+use crate::attrs::{FieldAttrs, VariantAttrs};
+use crate::context::MacroContext;
+
+pub fn generate_union_schema(context: &MacroContext, input: &DataEnum) -> TokenStream {
+    let schema_crate = context.schema_crate();
+
+    let variant_schemas: Vec<_> = input
+        .variants
+        .iter()
+        .enumerate()
+        .map(|(idx, variant)| {
+            let variant_attrs =
+                VariantAttrs::from_variant(variant).expect("failed to parse variant attributes");
+
+            let variant_name = variant_attrs
+                .rename
+                .clone()
+                .unwrap_or_else(|| context.apply_rename(&variant.ident.to_string()));
+
+            let schema_var = format_ident!("variant_{}_schema", idx);
+
+            let schema_build = match &variant.fields {
+                syn::Fields::Unit => {
+                    // Unit variant -> null schema
+                    quote! {
+                        let #schema_var = ctx.create_node(#schema_crate::SchemaNodeContent::Null);
+                    }
+                }
+                syn::Fields::Unnamed(fields) if fields.unnamed.len() == 1 => {
+                    // Newtype variant -> delegate to inner type
+                    let field_ty = &fields.unnamed[0].ty;
+                    quote! {
+                        let #schema_var = ctx.build::<#field_ty>();
+                    }
+                }
+                syn::Fields::Unnamed(fields) => {
+                    // Tuple variant -> tuple schema
+                    let field_builds: Vec<_> = fields
+                        .unnamed
+                        .iter()
+                        .enumerate()
+                        .map(|(fidx, f)| {
+                            let field_ty = &f.ty;
+                            let field_var = format_ident!("variant_{}_field_{}", idx, fidx);
+                            quote! {
+                                let #field_var = ctx.build::<#field_ty>();
+                            }
+                        })
+                        .collect();
+
+                    let field_vars: Vec<_> = (0..fields.unnamed.len())
+                        .map(|fidx| format_ident!("variant_{}_field_{}", idx, fidx))
+                        .collect();
+
+                    quote! {
+                        #(#field_builds)*
+                        let #schema_var = ctx.create_node(#schema_crate::SchemaNodeContent::Tuple(
+                            #schema_crate::TupleSchema {
+                                elements: vec![#(#field_vars),*],
+                                binding_style: None,
+                            }
+                        ));
+                    }
+                }
+                syn::Fields::Named(fields) => {
+                    // Struct variant -> record schema
+                    let field_builds: Vec<_> = fields
+                        .named
+                        .iter()
+                        .enumerate()
+                        .map(|(fidx, f)| {
+                            let field_ty = &f.ty;
+                            let field_var = format_ident!("variant_{}_field_{}", idx, fidx);
+                            quote! {
+                                let #field_var = ctx.build::<#field_ty>();
+                            }
+                        })
+                        .collect();
+
+                    let property_entries: Vec<_> = fields
+                        .named
+                        .iter()
+                        .enumerate()
+                        .map(|(fidx, f)| {
+                            let field_name = f.ident.as_ref().unwrap();
+                            let field_attrs = FieldAttrs::from_field(f)
+                                .expect("failed to parse field attributes");
+                            let field_name_str = field_attrs.rename.clone().unwrap_or_else(|| {
+                                context.apply_field_rename(&field_name.to_string())
+                            });
+                            let field_var = format_ident!("variant_{}_field_{}", idx, fidx);
+                            let is_optional = is_option_type(&f.ty);
+
+                            quote! {
+                                (
+                                    #field_name_str.to_string(),
+                                    #schema_crate::RecordFieldSchema {
+                                        schema: #field_var,
+                                        optional: #is_optional,
+                                        binding_style: None,
+                                    }
+                                )
+                            }
+                        })
+                        .collect();
+
+                    quote! {
+                        #(#field_builds)*
+                        let #schema_var = ctx.create_node(#schema_crate::SchemaNodeContent::Record(
+                            #schema_crate::RecordSchema {
+                                properties: [#(#property_entries),*].into_iter().collect(),
+                                unknown_fields: #schema_crate::UnknownFieldsPolicy::Deny,
+                            }
+                        ));
+                    }
+                }
+            };
+
+            (variant_name, schema_var, schema_build)
+        })
+        .collect();
+
+    // Collect all schema builds
+    let all_builds: Vec<_> = variant_schemas
+        .iter()
+        .map(|(_, _, build)| build.clone())
+        .collect();
+
+    // Create the variants BTreeMap entries
+    let variant_entries: Vec<_> = variant_schemas
+        .iter()
+        .map(|(name, schema_var, _)| {
+            quote! {
+                (#name.to_string(), #schema_var)
+            }
+        })
+        .collect();
+
+    let content = quote! {
+        use std::collections::{BTreeMap, HashSet};
+
+        #(#all_builds)*
+
+        #schema_crate::SchemaNodeContent::Union(#schema_crate::UnionSchema {
+            variants: BTreeMap::from([#(#variant_entries),*]),
+            unambiguous: HashSet::new(),
+            repr: ::eure_document::data_model::VariantRepr::default(),
+            deny_untagged: HashSet::new(),
+        })
+    };
+
+    context.impl_build_schema(content)
+}
+
+/// Check if a type is Option<T>
+fn is_option_type(ty: &syn::Type) -> bool {
+    if let syn::Type::Path(type_path) = ty
+        && let Some(segment) = type_path.path.segments.last()
+    {
+        return segment.ident == "Option";
+    }
+    false
+}

--- a/crates/eure-macros/src/config.rs
+++ b/crates/eure-macros/src/config.rs
@@ -15,6 +15,8 @@ pub struct MacroConfig {
     pub allow_unknown_extensions: bool,
     /// Custom error type for the ParseDocument impl.
     pub parse_error: Option<TokenStream>,
+    /// Type name for BuildSchema registration.
+    pub type_name: Option<String>,
 }
 
 impl MacroConfig {
@@ -33,6 +35,7 @@ impl MacroConfig {
             allow_unknown_fields: attrs.allow_unknown_fields,
             allow_unknown_extensions: attrs.allow_unknown_extensions,
             parse_error,
+            type_name: attrs.type_name,
         }
     }
 }

--- a/crates/eure-macros/src/lib.rs
+++ b/crates/eure-macros/src/lib.rs
@@ -4,6 +4,7 @@ use syn::parse_macro_input;
 use crate::{attrs::ContainerAttrs, config::MacroConfig, context::MacroContext};
 
 mod attrs;
+mod build_schema;
 pub(crate) mod config;
 pub(crate) mod context;
 mod into_document;
@@ -19,6 +20,12 @@ pub fn into_document_derive(input: proc_macro::TokenStream) -> proc_macro::Token
 pub fn parse_document_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as syn::DeriveInput);
     parse_document::derive(create_context(input)).into()
+}
+
+#[proc_macro_derive(BuildSchema, attributes(eure))]
+pub fn build_schema_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as syn::DeriveInput);
+    build_schema::derive(create_context(input)).into()
 }
 
 fn create_context(input: syn::DeriveInput) -> MacroContext {

--- a/crates/eure-macros/tests/build_schema/mod.rs
+++ b/crates/eure-macros/tests/build_schema/mod.rs
@@ -1,0 +1,2 @@
+mod simple_struct;
+mod simple_union;

--- a/crates/eure-macros/tests/build_schema/simple_struct.rs
+++ b/crates/eure-macros/tests/build_schema/simple_struct.rs
@@ -1,7 +1,58 @@
 //! Test BuildSchema derive for simple structs
 
 use eure::{BuildSchema, SchemaDocument};
-use eure_schema::{SchemaNodeContent, UnknownFieldsPolicy};
+use eure_schema::{SchemaNodeContent, SchemaNodeId, UnknownFieldsPolicy};
+
+// ============================================================================
+// Assertion helpers
+// ============================================================================
+
+fn assert_text(schema: &SchemaDocument, id: SchemaNodeId) {
+    assert!(matches!(schema.node(id).content, SchemaNodeContent::Text(_)));
+}
+
+fn assert_integer(schema: &SchemaDocument, id: SchemaNodeId) {
+    assert!(matches!(schema.node(id).content, SchemaNodeContent::Integer(_)));
+}
+
+fn assert_boolean(schema: &SchemaDocument, id: SchemaNodeId) {
+    assert!(matches!(schema.node(id).content, SchemaNodeContent::Boolean));
+}
+
+fn assert_null(schema: &SchemaDocument, id: SchemaNodeId) {
+    assert!(matches!(schema.node(id).content, SchemaNodeContent::Null));
+}
+
+fn assert_record<F>(schema: &SchemaDocument, id: SchemaNodeId, check: F)
+where
+    F: Fn(&SchemaDocument, &eure_schema::RecordSchema),
+{
+    let SchemaNodeContent::Record(record) = &schema.node(id).content else {
+        panic!("Expected Record, got {:?}", schema.node(id).content);
+    };
+    check(schema, record);
+}
+
+fn assert_union<F>(schema: &SchemaDocument, id: SchemaNodeId, check: F)
+where
+    F: Fn(&SchemaDocument, &eure_schema::UnionSchema),
+{
+    let SchemaNodeContent::Union(union) = &schema.node(id).content else {
+        panic!("Expected Union, got {:?}", schema.node(id).content);
+    };
+    check(schema, union);
+}
+
+fn assert_reference(schema: &SchemaDocument, id: SchemaNodeId, type_name: &str) {
+    let SchemaNodeContent::Reference(r) = &schema.node(id).content else {
+        panic!("Expected Reference, got {:?}", schema.node(id).content);
+    };
+    assert_eq!(r.name.as_ref(), type_name);
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
 
 #[derive(BuildSchema)]
 struct SimpleStruct {
@@ -13,42 +64,12 @@ struct SimpleStruct {
 #[test]
 fn test_simple_struct_schema() {
     let schema = SchemaDocument::of::<SimpleStruct>();
-
-    // Check root is a record
-    let root = schema.node(schema.root);
-    let SchemaNodeContent::Record(record) = &root.content else {
-        panic!("Expected Record, got {:?}", root.content);
-    };
-
-    // Check fields exist
-    assert!(record.properties.contains_key("name"));
-    assert!(record.properties.contains_key("age"));
-    assert!(record.properties.contains_key("active"));
-
-    // Check field types
-    let name_field = &record.properties["name"];
-    assert!(!name_field.optional);
-    assert!(matches!(
-        schema.node(name_field.schema).content,
-        SchemaNodeContent::Text(_)
-    ));
-
-    let age_field = &record.properties["age"];
-    assert!(!age_field.optional);
-    assert!(matches!(
-        schema.node(age_field.schema).content,
-        SchemaNodeContent::Integer(_)
-    ));
-
-    let active_field = &record.properties["active"];
-    assert!(!active_field.optional);
-    assert!(matches!(
-        schema.node(active_field.schema).content,
-        SchemaNodeContent::Boolean
-    ));
-
-    // Default unknown fields policy is Deny
-    assert!(matches!(record.unknown_fields, UnknownFieldsPolicy::Deny));
+    assert_record(&schema, schema.root, |s, rec| {
+        assert_eq!(rec.properties.len(), 3);
+        assert_text(s, rec.properties["name"].schema);
+        assert_integer(s, rec.properties["age"].schema);
+        assert_boolean(s, rec.properties["active"].schema);
+    });
 }
 
 #[derive(BuildSchema)]
@@ -61,9 +82,14 @@ struct UserWithTypeName {
 fn test_type_name_registration() {
     let schema = SchemaDocument::of::<UserWithTypeName>();
 
-    // Check type is registered
-    let user_type = schema.types.get(&"user".parse().unwrap());
-    assert!(user_type.is_some());
+    // Root should reference the type
+    assert_reference(&schema, schema.root, "user");
+
+    // Type should be registered
+    let user_id = *schema.types.values().next().expect("type registered");
+    assert_record(&schema, user_id, |s, rec| {
+        assert_text(s, rec.properties["name"].schema);
+    });
 }
 
 #[derive(BuildSchema)]
@@ -75,21 +101,17 @@ struct WithOptionalField {
 #[test]
 fn test_optional_field() {
     let schema = SchemaDocument::of::<WithOptionalField>();
-
-    let root = schema.node(schema.root);
-    let SchemaNodeContent::Record(record) = &root.content else {
-        panic!("Expected Record");
-    };
-
-    // Required field should not be optional
-    assert!(!record.properties["required"].optional);
-
-    // Option<T> field should be optional
-    assert!(record.properties["optional"].optional);
-
-    // The schema for Option<i32> should be a union
-    let optional_schema = schema.node(record.properties["optional"].schema);
-    assert!(matches!(optional_schema.content, SchemaNodeContent::Union(_)));
+    assert_record(&schema, schema.root, |s, rec| {
+        assert_text(s, rec.properties["required"].schema);
+        // Optional field should have a union schema (some|none)
+        assert_union(s, rec.properties["optional"].schema, |s, union| {
+            assert_eq!(union.variants.len(), 2);
+            assert_integer(s, union.variants["some"]);
+            assert_null(s, union.variants["none"]);
+        });
+        // Optional field should be marked as optional
+        assert!(rec.properties["optional"].optional);
+    });
 }
 
 #[derive(BuildSchema)]
@@ -102,17 +124,12 @@ struct RenamedFields {
 #[test]
 fn test_rename_all() {
     let schema = SchemaDocument::of::<RenamedFields>();
-
-    let root = schema.node(schema.root);
-    let SchemaNodeContent::Record(record) = &root.content else {
-        panic!("Expected Record");
-    };
-
-    // Fields should be renamed to kebab-case
-    assert!(record.properties.contains_key("user-name"));
-    assert!(record.properties.contains_key("email-address"));
-    assert!(!record.properties.contains_key("user_name"));
-    assert!(!record.properties.contains_key("email_address"));
+    assert_record(&schema, schema.root, |s, rec| {
+        assert!(rec.properties.contains_key("user-name"));
+        assert!(rec.properties.contains_key("email-address"));
+        assert_text(s, rec.properties["user-name"].schema);
+        assert_text(s, rec.properties["email-address"].schema);
+    });
 }
 
 #[derive(BuildSchema)]
@@ -124,11 +141,8 @@ struct AllowUnknownFields {
 #[test]
 fn test_allow_unknown_fields() {
     let schema = SchemaDocument::of::<AllowUnknownFields>();
-
-    let root = schema.node(schema.root);
-    let SchemaNodeContent::Record(record) = &root.content else {
-        panic!("Expected Record");
-    };
-
-    assert!(matches!(record.unknown_fields, UnknownFieldsPolicy::Allow));
+    assert_record(&schema, schema.root, |s, rec| {
+        assert_text(s, rec.properties["name"].schema);
+        assert!(matches!(rec.unknown_fields, UnknownFieldsPolicy::Allow));
+    });
 }

--- a/crates/eure-macros/tests/build_schema/simple_struct.rs
+++ b/crates/eure-macros/tests/build_schema/simple_struct.rs
@@ -1,0 +1,134 @@
+//! Test BuildSchema derive for simple structs
+
+use eure::{BuildSchema, SchemaDocument};
+use eure_schema::{SchemaNodeContent, UnknownFieldsPolicy};
+
+#[derive(BuildSchema)]
+struct SimpleStruct {
+    name: String,
+    age: u32,
+    active: bool,
+}
+
+#[test]
+fn test_simple_struct_schema() {
+    let schema = SchemaDocument::of::<SimpleStruct>();
+
+    // Check root is a record
+    let root = schema.node(schema.root);
+    let SchemaNodeContent::Record(record) = &root.content else {
+        panic!("Expected Record, got {:?}", root.content);
+    };
+
+    // Check fields exist
+    assert!(record.properties.contains_key("name"));
+    assert!(record.properties.contains_key("age"));
+    assert!(record.properties.contains_key("active"));
+
+    // Check field types
+    let name_field = &record.properties["name"];
+    assert!(!name_field.optional);
+    assert!(matches!(
+        schema.node(name_field.schema).content,
+        SchemaNodeContent::Text(_)
+    ));
+
+    let age_field = &record.properties["age"];
+    assert!(!age_field.optional);
+    assert!(matches!(
+        schema.node(age_field.schema).content,
+        SchemaNodeContent::Integer(_)
+    ));
+
+    let active_field = &record.properties["active"];
+    assert!(!active_field.optional);
+    assert!(matches!(
+        schema.node(active_field.schema).content,
+        SchemaNodeContent::Boolean
+    ));
+
+    // Default unknown fields policy is Deny
+    assert!(matches!(record.unknown_fields, UnknownFieldsPolicy::Deny));
+}
+
+#[derive(BuildSchema)]
+#[eure(type_name = "user")]
+struct UserWithTypeName {
+    name: String,
+}
+
+#[test]
+fn test_type_name_registration() {
+    let schema = SchemaDocument::of::<UserWithTypeName>();
+
+    // Check type is registered
+    let user_type = schema.types.get(&"user".parse().unwrap());
+    assert!(user_type.is_some());
+}
+
+#[derive(BuildSchema)]
+struct WithOptionalField {
+    required: String,
+    optional: Option<i32>,
+}
+
+#[test]
+fn test_optional_field() {
+    let schema = SchemaDocument::of::<WithOptionalField>();
+
+    let root = schema.node(schema.root);
+    let SchemaNodeContent::Record(record) = &root.content else {
+        panic!("Expected Record");
+    };
+
+    // Required field should not be optional
+    assert!(!record.properties["required"].optional);
+
+    // Option<T> field should be optional
+    assert!(record.properties["optional"].optional);
+
+    // The schema for Option<i32> should be a union
+    let optional_schema = schema.node(record.properties["optional"].schema);
+    assert!(matches!(optional_schema.content, SchemaNodeContent::Union(_)));
+}
+
+#[derive(BuildSchema)]
+#[eure(rename_all = "kebab-case")]
+struct RenamedFields {
+    user_name: String,
+    email_address: String,
+}
+
+#[test]
+fn test_rename_all() {
+    let schema = SchemaDocument::of::<RenamedFields>();
+
+    let root = schema.node(schema.root);
+    let SchemaNodeContent::Record(record) = &root.content else {
+        panic!("Expected Record");
+    };
+
+    // Fields should be renamed to kebab-case
+    assert!(record.properties.contains_key("user-name"));
+    assert!(record.properties.contains_key("email-address"));
+    assert!(!record.properties.contains_key("user_name"));
+    assert!(!record.properties.contains_key("email_address"));
+}
+
+#[derive(BuildSchema)]
+#[eure(allow_unknown_fields)]
+struct AllowUnknownFields {
+    name: String,
+}
+
+#[test]
+fn test_allow_unknown_fields() {
+    let schema = SchemaDocument::of::<AllowUnknownFields>();
+
+    let root = schema.node(schema.root);
+    let SchemaNodeContent::Record(record) = &root.content else {
+        panic!("Expected Record");
+    };
+
+    assert!(matches!(record.unknown_fields, UnknownFieldsPolicy::Allow));
+}

--- a/crates/eure-macros/tests/build_schema/simple_union.rs
+++ b/crates/eure-macros/tests/build_schema/simple_union.rs
@@ -1,0 +1,187 @@
+//! Test BuildSchema derive for enums (unions)
+
+use eure::{BuildSchema, SchemaDocument};
+use eure_schema::SchemaNodeContent;
+
+#[derive(BuildSchema)]
+enum SimpleEnum {
+    Active,
+    Inactive,
+    Pending,
+}
+
+#[test]
+fn test_simple_enum_schema() {
+    let schema = SchemaDocument::of::<SimpleEnum>();
+
+    let root = schema.node(schema.root);
+    let SchemaNodeContent::Union(union) = &root.content else {
+        panic!("Expected Union, got {:?}", root.content);
+    };
+
+    // Check variants exist
+    assert!(union.variants.contains_key("Active"));
+    assert!(union.variants.contains_key("Inactive"));
+    assert!(union.variants.contains_key("Pending"));
+
+    // Unit variants should have Null schema
+    for (_, &variant_id) in &union.variants {
+        assert!(matches!(
+            schema.node(variant_id).content,
+            SchemaNodeContent::Null
+        ));
+    }
+}
+
+#[derive(BuildSchema)]
+#[eure(rename_all = "kebab-case")]
+enum RenamedVariants {
+    UserActive,
+    UserInactive,
+}
+
+#[test]
+fn test_renamed_variants() {
+    let schema = SchemaDocument::of::<RenamedVariants>();
+
+    let root = schema.node(schema.root);
+    let SchemaNodeContent::Union(union) = &root.content else {
+        panic!("Expected Union");
+    };
+
+    assert!(union.variants.contains_key("user-active"));
+    assert!(union.variants.contains_key("user-inactive"));
+}
+
+#[derive(BuildSchema)]
+enum NewtypeVariants {
+    Text(String),
+    Number(i32),
+}
+
+#[test]
+fn test_newtype_variants() {
+    let schema = SchemaDocument::of::<NewtypeVariants>();
+
+    let root = schema.node(schema.root);
+    let SchemaNodeContent::Union(union) = &root.content else {
+        panic!("Expected Union");
+    };
+
+    // Text variant should have Text schema
+    let text_schema = schema.node(union.variants["Text"]);
+    assert!(matches!(text_schema.content, SchemaNodeContent::Text(_)));
+
+    // Number variant should have Integer schema
+    let number_schema = schema.node(union.variants["Number"]);
+    assert!(matches!(
+        number_schema.content,
+        SchemaNodeContent::Integer(_)
+    ));
+}
+
+#[derive(BuildSchema)]
+enum StructVariants {
+    User { name: String, age: u32 },
+    Admin { name: String, level: i32 },
+}
+
+#[test]
+fn test_struct_variants() {
+    let schema = SchemaDocument::of::<StructVariants>();
+
+    let root = schema.node(schema.root);
+    let SchemaNodeContent::Union(union) = &root.content else {
+        panic!("Expected Union");
+    };
+
+    // User variant should be a record
+    let user_schema = schema.node(union.variants["User"]);
+    let SchemaNodeContent::Record(user_record) = &user_schema.content else {
+        panic!("Expected Record for User variant");
+    };
+    assert!(user_record.properties.contains_key("name"));
+    assert!(user_record.properties.contains_key("age"));
+
+    // Admin variant should be a record
+    let admin_schema = schema.node(union.variants["Admin"]);
+    let SchemaNodeContent::Record(admin_record) = &admin_schema.content else {
+        panic!("Expected Record for Admin variant");
+    };
+    assert!(admin_record.properties.contains_key("name"));
+    assert!(admin_record.properties.contains_key("level"));
+}
+
+#[derive(BuildSchema)]
+enum TupleVariants {
+    Point(i32, i32),
+    Color(u8, u8, u8),
+}
+
+#[test]
+fn test_tuple_variants() {
+    let schema = SchemaDocument::of::<TupleVariants>();
+
+    let root = schema.node(schema.root);
+    let SchemaNodeContent::Union(union) = &root.content else {
+        panic!("Expected Union");
+    };
+
+    // Point variant should be a tuple
+    let point_schema = schema.node(union.variants["Point"]);
+    let SchemaNodeContent::Tuple(point_tuple) = &point_schema.content else {
+        panic!("Expected Tuple for Point variant");
+    };
+    assert_eq!(point_tuple.elements.len(), 2);
+
+    // Color variant should be a tuple
+    let color_schema = schema.node(union.variants["Color"]);
+    let SchemaNodeContent::Tuple(color_tuple) = &color_schema.content else {
+        panic!("Expected Tuple for Color variant");
+    };
+    assert_eq!(color_tuple.elements.len(), 3);
+}
+
+#[derive(BuildSchema)]
+enum MixedVariants {
+    Unit,
+    Newtype(String),
+    Tuple(i32, i32),
+    Struct { name: String },
+}
+
+#[test]
+fn test_mixed_variants() {
+    let schema = SchemaDocument::of::<MixedVariants>();
+
+    let root = schema.node(schema.root);
+    let SchemaNodeContent::Union(union) = &root.content else {
+        panic!("Expected Union");
+    };
+
+    assert_eq!(union.variants.len(), 4);
+
+    // Unit -> Null
+    assert!(matches!(
+        schema.node(union.variants["Unit"]).content,
+        SchemaNodeContent::Null
+    ));
+
+    // Newtype -> Text
+    assert!(matches!(
+        schema.node(union.variants["Newtype"]).content,
+        SchemaNodeContent::Text(_)
+    ));
+
+    // Tuple -> Tuple
+    assert!(matches!(
+        schema.node(union.variants["Tuple"]).content,
+        SchemaNodeContent::Tuple(_)
+    ));
+
+    // Struct -> Record
+    assert!(matches!(
+        schema.node(union.variants["Struct"]).content,
+        SchemaNodeContent::Record(_)
+    ));
+}

--- a/crates/eure-macros/tests/tests.rs
+++ b/crates/eure-macros/tests/tests.rs
@@ -5,3 +5,7 @@ mod unions {
 mod records {
     automod::dir!("./tests/records");
 }
+
+mod build_schema {
+    automod::dir!("./tests/build_schema");
+}

--- a/crates/eure-schema/src/build.rs
+++ b/crates/eure-schema/src/build.rs
@@ -1,0 +1,551 @@
+//! Schema building from Rust types
+//!
+//! This module provides the [`BuildSchema`] trait and [`SchemaBuilder`] for
+//! generating schema definitions from Rust types, either manually or via derive.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use eure_schema::{BuildSchema, SchemaDocument};
+//!
+//! #[derive(BuildSchema)]
+//! #[eure(type_name = "user")]
+//! struct User {
+//!     name: String,
+//!     age: Option<u32>,
+//! }
+//!
+//! let schema = SchemaDocument::of::<User>();
+//! ```
+
+use std::any::TypeId;
+use std::collections::HashMap;
+
+use crate::{SchemaDocument, SchemaMetadata, SchemaNode, SchemaNodeContent, SchemaNodeId};
+
+/// Trait for types that can build their schema representation.
+///
+/// This trait is typically derived using `#[derive(BuildSchema)]`, but can also
+/// be implemented manually for custom schema generation.
+///
+/// # Type Registration
+///
+/// Types can optionally provide a `type_name()` to register themselves in the
+/// schema's `$types` namespace. This is useful for:
+/// - Creating reusable type definitions
+/// - Enabling type references across the schema
+/// - Providing meaningful names in generated schemas
+///
+/// Primitive types typically return `None` for `type_name()`.
+pub trait BuildSchema {
+    /// The type name for registration in `$types` namespace.
+    ///
+    /// Return `Some("my-type")` to register this type as `$types.my-type`.
+    /// Return `None` (default) for inline/anonymous types.
+    fn type_name() -> Option<&'static str> {
+        None
+    }
+
+    /// Build the schema content for this type.
+    ///
+    /// Use `ctx.build::<T>()` for nested types - this handles caching
+    /// and recursion automatically.
+    fn build_schema(ctx: &mut SchemaBuilder) -> SchemaNodeContent;
+
+    /// Optional metadata for this type's schema node.
+    ///
+    /// Override to provide description, deprecation status, defaults, or examples.
+    fn schema_metadata() -> SchemaMetadata {
+        SchemaMetadata::default()
+    }
+}
+
+/// Builder for constructing schema documents from Rust types.
+///
+/// The builder maintains:
+/// - An arena of schema nodes
+/// - A cache by `TypeId` to prevent duplicate definitions and handle recursion
+/// - Type registrations for the `$types` namespace
+pub struct SchemaBuilder {
+    /// The schema document being built
+    doc: SchemaDocument,
+    /// Cache of built types by TypeId (prevents duplicates, handles recursion)
+    cache: HashMap<TypeId, SchemaNodeId>,
+}
+
+impl SchemaBuilder {
+    /// Create a new schema builder.
+    pub fn new() -> Self {
+        Self {
+            doc: SchemaDocument {
+                nodes: Vec::new(),
+                root: SchemaNodeId(0), // Will be set in finish()
+                types: HashMap::new(),
+            },
+            cache: HashMap::new(),
+        }
+    }
+
+    /// Build the schema for type `T`, with caching and recursion handling.
+    ///
+    /// This is the primary method for building nested types. It:
+    /// 1. Returns cached ID if already built (idempotent)
+    /// 2. Reserves a node slot before building (handles recursion)
+    /// 3. Calls `T::build_schema()` to get the content
+    /// 4. Registers the type name if provided
+    pub fn build<T: BuildSchema + 'static>(&mut self) -> SchemaNodeId {
+        let type_id = TypeId::of::<T>();
+
+        // Return cached if already built
+        if let Some(&id) = self.cache.get(&type_id) {
+            return id;
+        }
+
+        // Reserve a node slot (handles recursive types)
+        let id = self.reserve_node();
+        self.cache.insert(type_id, id);
+
+        // Build the schema content
+        let content = T::build_schema(self);
+        let metadata = T::schema_metadata();
+        self.set_node(id, content, metadata);
+
+        // Register type name if provided
+        if let Some(name) = T::type_name()
+            && let Ok(ident) = name.parse()
+        {
+            self.doc.types.insert(ident, id);
+        }
+
+        id
+    }
+
+    /// Create a schema node with the given content.
+    ///
+    /// Use this for creating anonymous/inline nodes that don't need caching.
+    /// For types that implement `BuildSchema`, prefer `build::<T>()`.
+    pub fn create_node(&mut self, content: SchemaNodeContent) -> SchemaNodeId {
+        let id = SchemaNodeId(self.doc.nodes.len());
+        self.doc.nodes.push(SchemaNode {
+            content,
+            metadata: SchemaMetadata::default(),
+            ext_types: HashMap::new(),
+        });
+        id
+    }
+
+    /// Create a schema node with content and metadata.
+    pub fn create_node_with_metadata(
+        &mut self,
+        content: SchemaNodeContent,
+        metadata: SchemaMetadata,
+    ) -> SchemaNodeId {
+        let id = SchemaNodeId(self.doc.nodes.len());
+        self.doc.nodes.push(SchemaNode {
+            content,
+            metadata,
+            ext_types: HashMap::new(),
+        });
+        id
+    }
+
+    /// Reserve a node slot, returning its ID.
+    ///
+    /// The node is initialized with `Any` content and must be finalized
+    /// with `set_node()` before the schema is complete.
+    fn reserve_node(&mut self) -> SchemaNodeId {
+        let id = SchemaNodeId(self.doc.nodes.len());
+        self.doc.nodes.push(SchemaNode {
+            content: SchemaNodeContent::Any, // Placeholder
+            metadata: SchemaMetadata::default(),
+            ext_types: HashMap::new(),
+        });
+        id
+    }
+
+    /// Set the content and metadata of a reserved node.
+    fn set_node(&mut self, id: SchemaNodeId, content: SchemaNodeContent, metadata: SchemaMetadata) {
+        let node = &mut self.doc.nodes[id.0];
+        node.content = content;
+        node.metadata = metadata;
+    }
+
+    /// Get mutable access to a node for adding ext_types or modifying metadata.
+    pub fn node_mut(&mut self, id: SchemaNodeId) -> &mut SchemaNode {
+        &mut self.doc.nodes[id.0]
+    }
+
+    /// Register a named type in the `$types` namespace.
+    pub fn register_type(&mut self, name: &str, id: SchemaNodeId) {
+        if let Ok(ident) = name.parse() {
+            self.doc.types.insert(ident, id);
+        }
+    }
+
+    /// Consume the builder and produce the final schema document.
+    pub fn finish(mut self, root: SchemaNodeId) -> SchemaDocument {
+        self.doc.root = root;
+        self.doc
+    }
+}
+
+impl Default for SchemaBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SchemaDocument {
+    /// Generate a schema document for type `T`.
+    ///
+    /// This is the main entry point for schema generation from Rust types.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use eure_schema::SchemaDocument;
+    ///
+    /// let schema = SchemaDocument::of::<MyType>();
+    /// ```
+    pub fn of<T: BuildSchema + 'static>() -> SchemaDocument {
+        let mut builder = SchemaBuilder::new();
+        let root = builder.build::<T>();
+        builder.finish(root)
+    }
+}
+
+// ============================================================================
+// Primitive Type Implementations
+// ============================================================================
+
+impl BuildSchema for String {
+    fn build_schema(_ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        SchemaNodeContent::Text(crate::TextSchema::default())
+    }
+}
+
+impl BuildSchema for &str {
+    fn build_schema(_ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        SchemaNodeContent::Text(crate::TextSchema::default())
+    }
+}
+
+impl BuildSchema for bool {
+    fn build_schema(_ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        SchemaNodeContent::Boolean
+    }
+}
+
+// Signed integers
+impl BuildSchema for i8 {
+    fn build_schema(_ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        SchemaNodeContent::Integer(crate::IntegerSchema::default())
+    }
+}
+
+impl BuildSchema for i16 {
+    fn build_schema(_ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        SchemaNodeContent::Integer(crate::IntegerSchema::default())
+    }
+}
+
+impl BuildSchema for i32 {
+    fn build_schema(_ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        SchemaNodeContent::Integer(crate::IntegerSchema::default())
+    }
+}
+
+impl BuildSchema for i64 {
+    fn build_schema(_ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        SchemaNodeContent::Integer(crate::IntegerSchema::default())
+    }
+}
+
+impl BuildSchema for i128 {
+    fn build_schema(_ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        SchemaNodeContent::Integer(crate::IntegerSchema::default())
+    }
+}
+
+impl BuildSchema for isize {
+    fn build_schema(_ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        SchemaNodeContent::Integer(crate::IntegerSchema::default())
+    }
+}
+
+// Unsigned integers
+impl BuildSchema for u8 {
+    fn build_schema(_ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        SchemaNodeContent::Integer(crate::IntegerSchema::default())
+    }
+}
+
+impl BuildSchema for u16 {
+    fn build_schema(_ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        SchemaNodeContent::Integer(crate::IntegerSchema::default())
+    }
+}
+
+impl BuildSchema for u32 {
+    fn build_schema(_ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        SchemaNodeContent::Integer(crate::IntegerSchema::default())
+    }
+}
+
+impl BuildSchema for u64 {
+    fn build_schema(_ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        SchemaNodeContent::Integer(crate::IntegerSchema::default())
+    }
+}
+
+impl BuildSchema for u128 {
+    fn build_schema(_ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        SchemaNodeContent::Integer(crate::IntegerSchema::default())
+    }
+}
+
+impl BuildSchema for usize {
+    fn build_schema(_ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        SchemaNodeContent::Integer(crate::IntegerSchema::default())
+    }
+}
+
+// Floats
+impl BuildSchema for f32 {
+    fn build_schema(_ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        SchemaNodeContent::Float(crate::FloatSchema {
+            precision: crate::FloatPrecision::F32,
+            ..Default::default()
+        })
+    }
+}
+
+impl BuildSchema for f64 {
+    fn build_schema(_ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        SchemaNodeContent::Float(crate::FloatSchema {
+            precision: crate::FloatPrecision::F64,
+            ..Default::default()
+        })
+    }
+}
+
+// Unit type
+impl BuildSchema for () {
+    fn build_schema(_ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        SchemaNodeContent::Null
+    }
+}
+
+// ============================================================================
+// Compound Type Implementations
+// ============================================================================
+
+/// Option<T> is represented as a union: some(T) | none(null)
+impl<T: BuildSchema + 'static> BuildSchema for Option<T> {
+    fn build_schema(ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        use std::collections::{BTreeMap, HashSet};
+
+        let some_schema = ctx.build::<T>();
+        let none_schema = ctx.create_node(SchemaNodeContent::Null);
+
+        SchemaNodeContent::Union(crate::UnionSchema {
+            variants: BTreeMap::from([
+                ("some".to_string(), some_schema),
+                ("none".to_string(), none_schema),
+            ]),
+            unambiguous: HashSet::new(),
+            repr: eure_document::data_model::VariantRepr::default(),
+            deny_untagged: HashSet::new(),
+        })
+    }
+}
+
+/// Result<T, E> is represented as a union: ok(T) | err(E)
+impl<T: BuildSchema + 'static, E: BuildSchema + 'static> BuildSchema for Result<T, E> {
+    fn build_schema(ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        use std::collections::{BTreeMap, HashSet};
+
+        let ok_schema = ctx.build::<T>();
+        let err_schema = ctx.build::<E>();
+
+        SchemaNodeContent::Union(crate::UnionSchema {
+            variants: BTreeMap::from([
+                ("ok".to_string(), ok_schema),
+                ("err".to_string(), err_schema),
+            ]),
+            unambiguous: HashSet::new(),
+            repr: eure_document::data_model::VariantRepr::default(),
+            deny_untagged: HashSet::new(),
+        })
+    }
+}
+
+/// Vec<T> is represented as an array with item type T
+impl<T: BuildSchema + 'static> BuildSchema for Vec<T> {
+    fn build_schema(ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        let item = ctx.build::<T>();
+        SchemaNodeContent::Array(crate::ArraySchema {
+            item,
+            min_length: None,
+            max_length: None,
+            unique: false,
+            contains: None,
+            binding_style: None,
+        })
+    }
+}
+
+/// HashMap<K, V> is represented as a map
+impl<K: BuildSchema + 'static, V: BuildSchema + 'static> BuildSchema
+    for std::collections::HashMap<K, V>
+{
+    fn build_schema(ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        let key = ctx.build::<K>();
+        let value = ctx.build::<V>();
+        SchemaNodeContent::Map(crate::MapSchema {
+            key,
+            value,
+            min_size: None,
+            max_size: None,
+        })
+    }
+}
+
+/// BTreeMap<K, V> is represented as a map
+impl<K: BuildSchema + 'static, V: BuildSchema + 'static> BuildSchema
+    for std::collections::BTreeMap<K, V>
+{
+    fn build_schema(ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        let key = ctx.build::<K>();
+        let value = ctx.build::<V>();
+        SchemaNodeContent::Map(crate::MapSchema {
+            key,
+            value,
+            min_size: None,
+            max_size: None,
+        })
+    }
+}
+
+/// Box<T> delegates to T
+impl<T: BuildSchema + 'static> BuildSchema for Box<T> {
+    fn build_schema(ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        T::build_schema(ctx)
+    }
+}
+
+/// Rc<T> delegates to T
+impl<T: BuildSchema + 'static> BuildSchema for std::rc::Rc<T> {
+    fn build_schema(ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        T::build_schema(ctx)
+    }
+}
+
+/// Arc<T> delegates to T
+impl<T: BuildSchema + 'static> BuildSchema for std::sync::Arc<T> {
+    fn build_schema(ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        T::build_schema(ctx)
+    }
+}
+
+// Tuples
+impl<A: BuildSchema + 'static> BuildSchema for (A,) {
+    fn build_schema(ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        let elements = vec![ctx.build::<A>()];
+        SchemaNodeContent::Tuple(crate::TupleSchema {
+            elements,
+            binding_style: None,
+        })
+    }
+}
+
+impl<A: BuildSchema + 'static, B: BuildSchema + 'static> BuildSchema for (A, B) {
+    fn build_schema(ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        let elements = vec![ctx.build::<A>(), ctx.build::<B>()];
+        SchemaNodeContent::Tuple(crate::TupleSchema {
+            elements,
+            binding_style: None,
+        })
+    }
+}
+
+impl<A: BuildSchema + 'static, B: BuildSchema + 'static, C: BuildSchema + 'static> BuildSchema
+    for (A, B, C)
+{
+    fn build_schema(ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        let elements = vec![ctx.build::<A>(), ctx.build::<B>(), ctx.build::<C>()];
+        SchemaNodeContent::Tuple(crate::TupleSchema {
+            elements,
+            binding_style: None,
+        })
+    }
+}
+
+impl<
+    A: BuildSchema + 'static,
+    B: BuildSchema + 'static,
+    C: BuildSchema + 'static,
+    D: BuildSchema + 'static,
+> BuildSchema for (A, B, C, D)
+{
+    fn build_schema(ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        let elements = vec![
+            ctx.build::<A>(),
+            ctx.build::<B>(),
+            ctx.build::<C>(),
+            ctx.build::<D>(),
+        ];
+        SchemaNodeContent::Tuple(crate::TupleSchema {
+            elements,
+            binding_style: None,
+        })
+    }
+}
+
+impl<
+    A: BuildSchema + 'static,
+    B: BuildSchema + 'static,
+    C: BuildSchema + 'static,
+    D: BuildSchema + 'static,
+    E: BuildSchema + 'static,
+> BuildSchema for (A, B, C, D, E)
+{
+    fn build_schema(ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        let elements = vec![
+            ctx.build::<A>(),
+            ctx.build::<B>(),
+            ctx.build::<C>(),
+            ctx.build::<D>(),
+            ctx.build::<E>(),
+        ];
+        SchemaNodeContent::Tuple(crate::TupleSchema {
+            elements,
+            binding_style: None,
+        })
+    }
+}
+
+impl<
+    A: BuildSchema + 'static,
+    B: BuildSchema + 'static,
+    C: BuildSchema + 'static,
+    D: BuildSchema + 'static,
+    E: BuildSchema + 'static,
+    F: BuildSchema + 'static,
+> BuildSchema for (A, B, C, D, E, F)
+{
+    fn build_schema(ctx: &mut SchemaBuilder) -> SchemaNodeContent {
+        let elements = vec![
+            ctx.build::<A>(),
+            ctx.build::<B>(),
+            ctx.build::<C>(),
+            ctx.build::<D>(),
+            ctx.build::<E>(),
+            ctx.build::<F>(),
+        ];
+        SchemaNodeContent::Tuple(crate::TupleSchema {
+            elements,
+            binding_style: None,
+        })
+    }
+}

--- a/crates/eure-schema/src/lib.rs
+++ b/crates/eure-schema/src/lib.rs
@@ -28,11 +28,14 @@
 //! **Reference:**
 //! - `Reference` - Type reference (local or cross-schema)
 
+pub mod build;
 pub mod convert;
 pub mod identifiers;
 pub mod parse;
 pub mod synth;
 pub mod validate;
+
+pub use build::{BuildSchema, SchemaBuilder};
 
 use eure_document::data_model::VariantRepr;
 use eure_document::document::EureDocument;

--- a/crates/eure/src/lib.rs
+++ b/crates/eure/src/lib.rs
@@ -7,5 +7,6 @@ pub mod value;
 pub use eure_document::data_model;
 pub use eure_document::eure;
 pub use eure_document::parse::ParseDocument;
-pub use eure_macros::ParseDocument;
+pub use eure_macros::{BuildSchema, ParseDocument};
 pub use eure_parol as parol;
+pub use eure_schema::{BuildSchema as BuildSchemaTrait, SchemaBuilder, SchemaDocument};


### PR DESCRIPTION
This implements a comprehensive schema generation system that allows deriving
schema definitions from Rust types:

- BuildSchema trait with build_schema() method returning SchemaNodeContent
- SchemaBuilder for arena-based schema document construction with TypeId caching
- SchemaDocument::of::<T>() high-level API for easy schema generation
- Primitive implementations for String, bool, integers, floats, ()
- Compound implementations for Option, Result, Vec, HashMap, BTreeMap, Box, tuples
- BuildSchema derive macro supporting structs (records) and enums (unions)
- Support for #[eure(type_name = "...")] to register types in $types namespace
- Support for #[eure(rename_all = "...")] and #[eure(allow_unknown_fields)]
- Automatic Option<T> detection to mark fields as optional