### PR TITLE
Add span string support for diagnostics test cases

### DIFF
--- a/test-suite/cases/editor/diagnostics/span-whitespace.eure
+++ b/test-suite/cases/editor/diagnostics/span-whitespace.eure
@@ -15,12 +15,7 @@ value = "invalid type"
 
 // Type mismatch diagnostic should point to "invalid type" (the value)
 // The span should not include the leading newline or spaces
-// Line 1: "$schema = \"schema.eure\"\n" = 24 bytes
-// Line 2: "\n" = 1 byte
-// Line 3: "value = " = 8 bytes, "\"invalid type\"" starts at 24 + 1 + 8 = 33
-// The string is 14 chars, ends at 33 + 14 = 47
 @ diagnostics[]
 severity = "error"
 message = "Type mismatch: expected integer, got text at path value"
-start = 33
-end = 47
+span = "\"invalid type\""

--- a/test-suite/cases/editor/diagnostics/type-mismatch-span.eure
+++ b/test-suite/cases/editor/diagnostics/type-mismatch-span.eure
@@ -13,10 +13,7 @@ name = 123
 ```
 
 // Type mismatch diagnostic should point to "123" (the value)
-// Line 1: "$schema = \"schema.eure\"\n" = 24 bytes
-// Line 2: "name = " = 7 bytes, "123" starts at offset 24 + 7 = 31, ends at 31 + 3 = 34
 @ diagnostics[]
 severity = "error"
 message = "Type mismatch: expected text, got integer at path name"
-start = 31
-end = 34
+span = "123"

--- a/test-suite/cases/editor/diagnostics/value-span-whitespace.eure
+++ b/test-suite/cases/editor/diagnostics/value-span-whitespace.eure
@@ -15,12 +15,7 @@ $schema = "schema.eure"
 
 // Type mismatch diagnostic should point to the string value
 // The span should NOT include the preceding whitespace/newline
-// Line 1: "$schema = \"schema.eure\"\n" = 24 bytes
-// Line 2: "\n" = 1 byte
-// Line 3: "  myfield = " = 12 bytes, the string starts at 24 + 1 + 12 = 37
-// The string "\"string instead of integer\"" is 27 chars, ends at 37 + 27 = 64
 @ diagnostics[]
 severity = "error"
 message = "Type mismatch: expected integer, got text at path myfield"
-start = 37
-end = 64
+span = "\"string instead of integer\""

--- a/test-suite/src/parser.rs
+++ b/test-suite/src/parser.rs
@@ -35,6 +35,11 @@ pub struct DiagnosticItem {
     pub message: Option<String>,
     #[eure(default)]
     pub code: Option<String>,
+    /// Expected span text (exact match in editor content).
+    /// More readable than start/end offsets. If specified, the text must appear
+    /// exactly once in the editor content.
+    #[eure(default)]
+    pub span: Option<String>,
     /// Expected start byte offset (for span verification)
     #[eure(default)]
     pub start: Option<i64>,

--- a/test-suite/src/scenarios.rs
+++ b/test-suite/src/scenarios.rs
@@ -151,6 +151,17 @@ pub enum ScenarioError {
         expected: i64,
         actual: i64,
     },
+    /// Span string not found in editor content
+    SpanStringNotFound {
+        diagnostic_index: usize,
+        span: String,
+    },
+    /// Span string found multiple times in editor content (ambiguous)
+    SpanStringAmbiguous {
+        diagnostic_index: usize,
+        span: String,
+        occurrences: usize,
+    },
     /// Query error
     QueryError(QueryError),
     FileNotFound(TextFile),
@@ -402,6 +413,27 @@ impl std::fmt::Display for ScenarioError {
                     f,
                     "Diagnostic span mismatch at index {}.\nField '{}': expected {}, got {}",
                     diagnostic_index, field, expected, actual
+                )
+            }
+            ScenarioError::SpanStringNotFound {
+                diagnostic_index,
+                span,
+            } => {
+                write!(
+                    f,
+                    "Diagnostic span string not found at index {}.\nSpan: {:?}",
+                    diagnostic_index, span
+                )
+            }
+            ScenarioError::SpanStringAmbiguous {
+                diagnostic_index,
+                span,
+                occurrences,
+            } => {
+                write!(
+                    f,
+                    "Diagnostic span string is ambiguous at index {}.\nSpan {:?} found {} times (must be unique)",
+                    diagnostic_index, span, occurrences
                 )
             }
             ScenarioError::QueryError(error) => {

--- a/test-suite/src/scenarios/diagnostics.rs
+++ b/test-suite/src/scenarios/diagnostics.rs
@@ -4,6 +4,60 @@ use query_flow::Db;
 use crate::parser::DiagnosticItem;
 use crate::scenarios::{Scenario, ScenarioError};
 
+/// Resolved span positions from either explicit start/end or span string lookup.
+struct ResolvedSpan {
+    start: Option<i64>,
+    end: Option<i64>,
+}
+
+/// Find a span string in editor content and return its byte offsets.
+/// Returns an error if the string is not found or found multiple times.
+fn resolve_span_string(
+    editor_content: &str,
+    span: &str,
+    diagnostic_index: usize,
+) -> Result<(i64, i64), ScenarioError> {
+    let matches: Vec<_> = editor_content.match_indices(span).collect();
+
+    match matches.len() {
+        0 => Err(ScenarioError::SpanStringNotFound {
+            diagnostic_index,
+            span: span.to_string(),
+        }),
+        1 => {
+            let start = matches[0].0 as i64;
+            let end = start + span.len() as i64;
+            Ok((start, end))
+        }
+        n => Err(ScenarioError::SpanStringAmbiguous {
+            diagnostic_index,
+            span: span.to_string(),
+            occurrences: n,
+        }),
+    }
+}
+
+/// Resolve span positions for a diagnostic item.
+/// Priority: span string > explicit start/end
+fn resolve_span(
+    expected: &DiagnosticItem,
+    editor_content: &str,
+    diagnostic_index: usize,
+) -> Result<ResolvedSpan, ScenarioError> {
+    if let Some(span) = &expected.span {
+        let (start, end) = resolve_span_string(editor_content, span, diagnostic_index)?;
+        Ok(ResolvedSpan {
+            start: Some(start),
+            end: Some(end),
+        })
+    } else {
+        Ok(ResolvedSpan {
+            start: expected.start,
+            end: expected.end,
+        })
+    }
+}
+
 /// Diagnostics test scenario
 #[derive(Debug, Clone)]
 pub struct DiagnosticsScenario {
@@ -44,22 +98,27 @@ impl Scenario for DiagnosticsScenario {
             });
         }
 
-        // Verify span positions if specified
-        verify_span_positions(&self.diagnostics, &actual)?;
+        // Verify span positions if specified (span string or start/end)
+        let editor_content = db.asset(self.editor)?.suspend()?;
+        verify_span_positions(&self.diagnostics, &actual, editor_content.get())?;
 
         Ok(())
     }
 }
 
 /// Verify that diagnostic spans match expected positions.
-/// Only checks diagnostics where start/end are explicitly specified.
+/// Supports both span string (resolved to offsets) and explicit start/end.
 fn verify_span_positions(
     expected: &[DiagnosticItem],
     actual: &[DiagnosticMessage],
+    editor_content: &str,
 ) -> Result<(), ScenarioError> {
     for (i, (exp, act)) in expected.iter().zip(actual.iter()).enumerate() {
+        // Resolve span positions (from span string or explicit start/end)
+        let resolved = resolve_span(exp, editor_content, i)?;
+
         // Check start position if specified
-        if let Some(expected_start) = exp.start {
+        if let Some(expected_start) = resolved.start {
             let actual_start = act.start as i64;
             if actual_start != expected_start {
                 return Err(ScenarioError::SpanMismatch {
@@ -72,7 +131,7 @@ fn verify_span_positions(
         }
 
         // Check end position if specified
-        if let Some(expected_end) = exp.end {
+        if let Some(expected_end) = resolved.end {
             let actual_end = act.end as i64;
             if actual_end != expected_end {
                 return Err(ScenarioError::SpanMismatch {


### PR DESCRIPTION
Allow specifying expected diagnostic spans using exact text strings
instead of byte offsets. This makes tests more readable and maintainable.

Changes:
- Add `span` field to DiagnosticItem (optional string)
- When `span` is specified, resolve it to byte offsets by searching
  the editor content for an exact match
- Error if span string not found or found multiple times (ambiguous)
- Existing start/end fields still work for edge cases where span
  string would be ambiguous
- Update 3 test cases to use the new span syntax