### PR TITLE
Remove pub from inner fields of Map, NodeArray, and NodeTuple

### DIFF
--- a/crates/eure-document/src/data_model.rs
+++ b/crates/eure-document/src/data_model.rs
@@ -93,18 +93,16 @@ impl VariantRepr {
                 Some(VariantRepr::Untagged)
             }
             NodeValue::Map(map) => {
-                let tag =
-                    map.0
-                        .get(&ObjectKey::String("tag".to_string()))
-                        .and_then(|&id| match &doc.node(id).content {
-                            NodeValue::Primitive(PrimitiveValue::Text(t)) => {
-                                Some(t.as_str().to_string())
-                            }
-                            _ => None,
-                        });
+                let tag = map
+                    .get(&ObjectKey::String("tag".to_string()))
+                    .and_then(|&id| match &doc.node(id).content {
+                        NodeValue::Primitive(PrimitiveValue::Text(t)) => {
+                            Some(t.as_str().to_string())
+                        }
+                        _ => None,
+                    });
 
                 let content = map
-                    .0
                     .get(&ObjectKey::String("content".to_string()))
                     .and_then(|&id| match &doc.node(id).content {
                         NodeValue::Primitive(PrimitiveValue::Text(t)) => {

--- a/crates/eure-document/src/document.rs
+++ b/crates/eure-document/src/document.rs
@@ -100,11 +100,11 @@ impl EureDocument {
     }
 
     fn node_arrays_equal(&self, arr1: &NodeArray, other: &EureDocument, arr2: &NodeArray) -> bool {
-        if arr1.0.len() != arr2.0.len() {
+        if arr1.len() != arr2.len() {
             return false;
         }
 
-        for (child_id1, child_id2) in arr1.0.iter().zip(arr2.0.iter()) {
+        for (child_id1, child_id2) in arr1.iter().zip(arr2.iter()) {
             if !self.nodes_equal(*child_id1, other, *child_id2) {
                 return false;
             }
@@ -114,11 +114,11 @@ impl EureDocument {
     }
 
     fn node_tuples_equal(&self, tup1: &NodeTuple, other: &EureDocument, tup2: &NodeTuple) -> bool {
-        if tup1.0.len() != tup2.0.len() {
+        if tup1.len() != tup2.len() {
             return false;
         }
 
-        for (child_id1, child_id2) in tup1.0.iter().zip(tup2.0.iter()) {
+        for (child_id1, child_id2) in tup1.iter().zip(tup2.iter()) {
             if !self.nodes_equal(*child_id1, other, *child_id2) {
                 return false;
             }
@@ -128,12 +128,12 @@ impl EureDocument {
     }
 
     fn node_maps_equal(&self, map1: &NodeMap, other: &EureDocument, map2: &NodeMap) -> bool {
-        if map1.0.len() != map2.0.len() {
+        if map1.len() != map2.len() {
             return false;
         }
 
-        for (key1, &child_id1) in &map1.0 {
-            match map2.0.get(key1) {
+        for (key1, &child_id1) in map1.iter() {
+            match map2.get(key1) {
                 Some(&child_id2) => {
                     if !self.nodes_equal(child_id1, other, child_id2) {
                         return false;
@@ -515,7 +515,7 @@ mod tests {
             .node_id;
 
         let tuple = doc.node(tuple_id).as_tuple().expect("Expected tuple");
-        assert_eq!(tuple.0, vec![node_id]);
+        assert_eq!(tuple.to_vec(), vec![node_id]);
     }
 
     #[test]
@@ -537,7 +537,7 @@ mod tests {
             .node_id;
 
         let tuple = doc.node(tuple_id).as_tuple().expect("Expected tuple");
-        assert_eq!(tuple.0, vec![node_id1, node_id2]);
+        assert_eq!(tuple.to_vec(), vec![node_id1, node_id2]);
     }
 
     #[test]
@@ -584,7 +584,7 @@ mod tests {
             .node_id;
 
         let array = doc.node(array_id).as_array().expect("Expected array");
-        assert_eq!(array.0, vec![node_id]);
+        assert_eq!(array.to_vec(), vec![node_id]);
     }
 
     #[test]
@@ -606,7 +606,7 @@ mod tests {
             .node_id;
 
         let array = doc.node(array_id).as_array().expect("Expected array");
-        assert_eq!(array.0, vec![node_id1, node_id2]);
+        assert_eq!(array.to_vec(), vec![node_id1, node_id2]);
     }
 
     #[test]
@@ -695,7 +695,7 @@ mod tests {
         assert!(result.is_ok());
 
         let tuple = doc.node(tuple_id).as_tuple().expect("Expected tuple");
-        assert_eq!(tuple.0.len(), 1);
+        assert_eq!(tuple.len(), 1);
     }
 
     #[test]
@@ -711,7 +711,7 @@ mod tests {
         assert!(result.is_ok());
 
         let array = doc.node(array_id).as_array().expect("Expected array");
-        assert_eq!(array.0.len(), 1);
+        assert_eq!(array.len(), 1);
     }
 
     #[test]
@@ -727,7 +727,7 @@ mod tests {
         assert!(result.is_ok());
 
         let array = doc.node(array_id).as_array().expect("Expected array");
-        assert_eq!(array.0.len(), 1);
+        assert_eq!(array.len(), 1);
     }
 
     #[test]
@@ -855,9 +855,9 @@ mod tests {
 
         // Verify both nodes exist in array
         let array = doc.node(parent_id).as_array().expect("Expected array");
-        assert_eq!(array.0.len(), 2);
-        assert_eq!(array.0[0], node_id1);
-        assert_eq!(array.0[1], node_id2);
+        assert_eq!(array.len(), 2);
+        assert_eq!(array.get(0).unwrap(), node_id1);
+        assert_eq!(array.get(1).unwrap(), node_id2);
     }
 
     #[test]

--- a/crates/eure-document/src/document/node.rs
+++ b/crates/eure-document/src/document/node.rs
@@ -227,13 +227,13 @@ impl From<PrimitiveValue> for NodeValue {
     }
 }
 
-// TODO: Remove `pub`
 #[derive(Debug, Default, Clone, PartialEq, Eq, Plural)]
-pub struct NodeArray(pub Vec<NodeId>);
+#[plural(len, is_empty, iter, into_iter, new)]
+pub struct NodeArray(Vec<NodeId>);
 
-// TODO: Remove `pub`
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash, Plural)]
-pub struct NodeTuple(pub Vec<NodeId>);
+#[plural(len, is_empty, iter, into_iter, new)]
+pub struct NodeTuple(Vec<NodeId>);
 
 pub type NodeMap = Map<ObjectKey, NodeId>;
 
@@ -257,6 +257,14 @@ impl NodeTuple {
         self.0.insert(index as usize, node_id);
         Ok(())
     }
+
+    pub fn to_vec(&self) -> Vec<NodeId> {
+        self.0.clone()
+    }
+
+    pub fn from_vec(vec: Vec<NodeId>) -> Self {
+        Self(vec)
+    }
 }
 
 impl NodeArray {
@@ -279,6 +287,14 @@ impl NodeArray {
         self.0.insert(index, node_id);
         Ok(())
     }
+
+    pub fn to_vec(&self) -> Vec<NodeId> {
+        self.0.clone()
+    }
+
+    pub fn from_vec(vec: Vec<NodeId>) -> Self {
+        Self(vec)
+    }
 }
 
 #[cfg(test)]
@@ -297,7 +313,7 @@ mod tests {
         };
 
         let map = node.require_map().expect("Should convert to map");
-        assert_eq!(map.0.len(), 0);
+        assert_eq!(map.len(), 0);
 
         // Verify content was changed
         assert!(node.as_map().is_some());
@@ -311,7 +327,7 @@ mod tests {
         };
 
         let map = node.require_map().expect("Should return existing map");
-        assert_eq!(map.0.len(), 0);
+        assert_eq!(map.len(), 0);
     }
 
     #[test]
@@ -333,7 +349,7 @@ mod tests {
         };
 
         let tuple = node.require_tuple().expect("Should convert to tuple");
-        assert_eq!(tuple.0.len(), 0);
+        assert_eq!(tuple.len(), 0);
 
         // Verify content was changed
         assert!(node.as_tuple().is_some());
@@ -347,7 +363,7 @@ mod tests {
         };
 
         let tuple = node.require_tuple().expect("Should return existing tuple");
-        assert_eq!(tuple.0.len(), 0);
+        assert_eq!(tuple.len(), 0);
     }
 
     #[test]
@@ -369,7 +385,7 @@ mod tests {
         };
 
         let array = node.require_array().expect("Should convert to array");
-        assert_eq!(array.0.len(), 0);
+        assert_eq!(array.len(), 0);
 
         // Verify content was changed
         assert!(node.as_array().is_some());
@@ -383,7 +399,7 @@ mod tests {
         };
 
         let array = node.require_array().expect("Should return existing array");
-        assert_eq!(array.0.len(), 0);
+        assert_eq!(array.len(), 0);
     }
 
     #[test]

--- a/crates/eure-document/src/map.rs
+++ b/crates/eure-document/src/map.rs
@@ -2,10 +2,9 @@ use indexmap::IndexMap;
 
 use crate::prelude_internal::*;
 
-// TODO: Remove `pub`
 #[derive(Debug, Clone, Plural)]
 #[plural(len, is_empty, iter, into_iter, into_iter_ref, new)]
-pub struct Map<K, V>(pub IndexMap<K, V>);
+pub struct Map<K, V>(IndexMap<K, V>);
 
 impl<K: Eq + std::hash::Hash, V: Eq> Eq for Map<K, V> {}
 impl<K: Eq + std::hash::Hash, V: PartialEq> PartialEq for Map<K, V> {

--- a/crates/eure-json/src/lib.rs
+++ b/crates/eure-json/src/lib.rs
@@ -77,21 +77,21 @@ fn convert_node(
         NodeValue::Primitive(prim) => convert_primitive(prim),
         NodeValue::Array(arr) => {
             let mut result = Vec::new();
-            for &child_id in &arr.0 {
+            for &child_id in arr.iter() {
                 result.push(convert_node(doc, child_id, config)?);
             }
             Ok(JsonValue::Array(result))
         }
         NodeValue::Tuple(tuple) => {
             let mut result = Vec::new();
-            for &child_id in &tuple.0 {
+            for &child_id in tuple.iter() {
                 result.push(convert_node(doc, child_id, config)?);
             }
             Ok(JsonValue::Array(result))
         }
         NodeValue::Map(map) => {
             let mut result = serde_json::Map::new();
-            for (key, &child_id) in &map.0 {
+            for (key, &child_id) in map.iter() {
                 let key_string = convert_object_key(key)?;
                 let value = convert_node(doc, child_id, config)?;
                 result.insert(key_string, value);
@@ -212,21 +212,21 @@ fn convert_node_content_only(
         NodeValue::Primitive(prim) => convert_primitive(prim),
         NodeValue::Array(arr) => {
             let mut result = Vec::new();
-            for &child_id in &arr.0 {
+            for &child_id in arr.iter() {
                 result.push(convert_node(doc, child_id, config)?);
             }
             Ok(JsonValue::Array(result))
         }
         NodeValue::Tuple(tuple) => {
             let mut result = Vec::new();
-            for &child_id in &tuple.0 {
+            for &child_id in tuple.iter() {
                 result.push(convert_node(doc, child_id, config)?);
             }
             Ok(JsonValue::Array(result))
         }
         NodeValue::Map(map) => {
             let mut result = serde_json::Map::new();
-            for (key, &child_id) in &map.0 {
+            for (key, &child_id) in map.iter() {
                 let key_string = convert_object_key(key)?;
                 let value = convert_node(doc, child_id, config)?;
                 result.insert(key_string, value);
@@ -312,7 +312,7 @@ fn convert_json_to_node(doc: &mut EureDocument, node_id: NodeId, value: &JsonVal
                 let child_id = doc.create_node(NodeValue::hole());
                 convert_json_to_node(doc, child_id, item);
                 if let NodeValue::Array(ref mut array) = doc.node_mut(node_id).content {
-                    array.0.push(child_id);
+                    let _ = array.push(child_id);
                 }
             }
         }
@@ -322,7 +322,7 @@ fn convert_json_to_node(doc: &mut EureDocument, node_id: NodeId, value: &JsonVal
                 let child_id = doc.create_node(NodeValue::hole());
                 convert_json_to_node(doc, child_id, val);
                 if let NodeValue::Map(ref mut map) = doc.node_mut(node_id).content {
-                    map.0.insert(ObjectKey::String(key.clone()), child_id);
+                    map.insert(ObjectKey::String(key.clone()), child_id);
                 }
             }
         }

--- a/crates/eure-schema/src/convert.rs
+++ b/crates/eure-schema/src/convert.rs
@@ -130,7 +130,7 @@ impl<'a> Converter<'a> {
         if let Some(types_node_id) = node.extensions.get(&types_ident) {
             let types_node = self.doc.node(*types_node_id);
             if let NodeValue::Map(map) = &types_node.content {
-                for (key, &node_id) in map.0.iter() {
+                for (key, &node_id) in map.iter() {
                     if let ObjectKey::String(name) = key {
                         let type_name: Identifier = name
                             .parse()
@@ -469,16 +469,15 @@ impl<'a> Converter<'a> {
             }
             NodeValue::Array(arr) => {
                 dest.set_content(dest_node_id, NodeValue::empty_array());
-                arr.0.to_vec()
+                arr.to_vec()
             }
             NodeValue::Tuple(tup) => {
                 dest.set_content(dest_node_id, NodeValue::empty_tuple());
-                tup.0.to_vec()
+                tup.to_vec()
             }
             NodeValue::Map(map) => {
                 dest.set_content(dest_node_id, NodeValue::empty_map());
-                map.0
-                    .iter()
+                map.iter()
                     .map(|(k, &v)| (k.clone(), v))
                     .collect::<Vec<_>>()
                     .into_iter()
@@ -519,7 +518,7 @@ impl<'a> Converter<'a> {
                 }
             }
             NodeValue::Map(map) => {
-                for (key, &child_id) in map.0.iter() {
+                for (key, &child_id) in map.iter() {
                     let new_child_id = dest
                         .add_map_child(key.clone(), dest_node_id)
                         .map_err(|e| ConversionError::UnsupportedConstruct(e.to_string()))?
@@ -756,9 +755,7 @@ mod tests {
 
         // Create root as record with field: { name = `text` }
         let mut root_map = NodeMap::default();
-        root_map
-            .0
-            .insert(ObjectKey::String("name".to_string()), field_value_id);
+        root_map.insert(ObjectKey::String("name".to_string()), field_value_id);
         doc.node_mut(root_id).content = NodeValue::Map(root_map);
 
         doc
@@ -804,9 +801,7 @@ mod tests {
             Text::inline_implicit("text"),
         )));
         let mut ext_type_map = NodeMap::default();
-        ext_type_map
-            .0
-            .insert(ObjectKey::Number(0.into()), ext_type_value_id);
+        ext_type_map.insert(ObjectKey::Number(0.into()), ext_type_value_id);
 
         let ext_type_id = doc.create_node(NodeValue::Map(ext_type_map));
         doc.node_mut(field_value_id)
@@ -815,9 +810,7 @@ mod tests {
 
         // Create root as record
         let mut root_map = NodeMap::default();
-        root_map
-            .0
-            .insert(ObjectKey::String("name".to_string()), field_value_id);
+        root_map.insert(ObjectKey::String("name".to_string()), field_value_id);
         doc.node_mut(root_id).content = NodeValue::Map(root_map);
 
         let err = document_to_schema(&doc).unwrap_err();
@@ -855,9 +848,7 @@ mod tests {
 
         // Create $ext-type map
         let mut ext_type_map = NodeMap::default();
-        ext_type_map
-            .0
-            .insert(ObjectKey::String("desc".to_string()), ext_type_value_id);
+        ext_type_map.insert(ObjectKey::String("desc".to_string()), ext_type_value_id);
 
         let ext_type_id = doc.create_node(NodeValue::Map(ext_type_map));
         doc.node_mut(field_value_id)
@@ -866,9 +857,7 @@ mod tests {
 
         // Create root as record
         let mut root_map = NodeMap::default();
-        root_map
-            .0
-            .insert(ObjectKey::String("name".to_string()), field_value_id);
+        root_map.insert(ObjectKey::String("name".to_string()), field_value_id);
         doc.node_mut(root_id).content = NodeValue::Map(root_map);
 
         let err = document_to_schema(&doc).unwrap_err();
@@ -987,10 +976,8 @@ mod tests {
 
         // Create the variants map
         let mut variants_map = NodeMap::default();
-        variants_map
-            .0
-            .insert(ObjectKey::String("any".to_string()), any_variant_node);
-        variants_map.0.insert(
+        variants_map.insert(ObjectKey::String("any".to_string()), any_variant_node);
+        variants_map.insert(
             ObjectKey::String("literal".to_string()),
             literal_variant_node,
         );
@@ -1006,9 +993,7 @@ mod tests {
 
         // Create root map with variants
         let mut root_map = NodeMap::default();
-        root_map
-            .0
-            .insert(ObjectKey::String("variants".to_string()), variants_node);
+        root_map.insert(ObjectKey::String("variants".to_string()), variants_node);
 
         doc.node_mut(root_id).content = NodeValue::Map(root_map);
         doc.node_mut(root_id)

--- a/crates/eure-schema/src/parse.rs
+++ b/crates/eure-schema/src/parse.rs
@@ -599,7 +599,7 @@ impl ParseDocument<'_> for ParsedSchemaNodeContent {
                 // Array shorthand: [type] represents an array schema
                 if arr.len() == 1 {
                     Ok(ParsedSchemaNodeContent::Array(ParsedArraySchema {
-                        item: arr.0[0],
+                        item: arr.get(0).unwrap(),
                         min_length: None,
                         max_length: None,
                         unique: false,
@@ -623,7 +623,7 @@ impl ParseDocument<'_> for ParsedSchemaNodeContent {
             NodeValue::Tuple(tup) => {
                 // Tuple shorthand: (type1, type2, ...) represents a tuple schema
                 Ok(ParsedSchemaNodeContent::Tuple(ParsedTupleSchema {
-                    elements: tup.0.clone(),
+                    elements: tup.to_vec(),
                     binding_style: None,
                 }))
             }


### PR DESCRIPTION
This encapsulates the internal data structures by making inner fields
private and exposing public methods for access. Changes include:

- Remove pub from Map<K, V> inner IndexMap field
- Remove pub from NodeArray inner Vec<NodeId> field
- Remove pub from NodeTuple inner Vec<NodeId> field
- Add from_vec() methods to NodeArray and NodeTuple for construction
- Add #[plural(...)] attributes to generate len, is_empty, iter methods
- Update all usages to use public methods instead of direct field access

Resolves TODO comments in map.rs and node.rs about removing pub fields.