### PR TITLE
Add benchmark for query system overhead in eure-json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "annotate-snippets"
 version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,13 +492,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "catppuccin"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09e258c2f1b845bc3f6fe9790f217f377246e5605ff003e6537d5b2baf44e69c"
 dependencies = [
  "css-colors",
- "itertools",
+ "itertools 0.14.0",
  "prettyplease",
  "proc-macro2",
  "quote",
@@ -857,6 +869,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1967,9 +2015,12 @@ name = "eure-json"
 version = "0.1.4"
 dependencies = [
  "ahash",
+ "criterion",
  "eure",
  "eure-document",
  "eure-fmt",
+ "eure-parol",
+ "eure-tree",
  "indexmap",
  "num-bigint",
  "query-flow",
@@ -2923,10 +2974,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -3525,6 +3596,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3708,6 +3785,34 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "png"
@@ -4079,7 +4184,7 @@ dependencies = [
  "built",
  "cfg-if",
  "interpolate_name",
- "itertools",
+ "itertools 0.14.0",
  "libc",
  "libfuzzer-sys",
  "log",
@@ -5156,6 +5261,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ query-flow = "0.13"
 glob = "0.3"
 url = "2"
 reqwest = { version = "0.13", features = ["blocking"] }
+criterion = "0.5"
 
 # For faster parser generation
 [profile.dev.package.parol]

--- a/crates/eure-json/Cargo.toml
+++ b/crates/eure-json/Cargo.toml
@@ -20,3 +20,12 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 query-flow = { workspace = true }
+eure-parol = { workspace = true }
+
+[dev-dependencies]
+criterion = { workspace = true }
+eure-tree = { workspace = true }
+
+[[bench]]
+name = "conversion"
+harness = false

--- a/crates/eure-json/benches/conversion.rs
+++ b/crates/eure-json/benches/conversion.rs
@@ -1,0 +1,302 @@
+//! Benchmarks comparing query system overhead vs manual pipeline calls.
+//!
+//! This benchmark measures the overhead of the query-flow system by comparing:
+//! 1. Query pipeline: Input -> CST -> EureDocument -> JSON via query runtime
+//! 2. Manual pipeline: Direct function calls without query system
+//!
+//! Run with: cargo bench -p eure-json
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use eure::document::{EureDocument, cst_to_document};
+use eure::query::{TextFile, TextFileContent, build_runtime};
+use eure_json::{Config, EureToJson, document_to_value};
+use eure_parol::parse_tolerant;
+use eure_tree::prelude::Cst;
+use query_flow::DurabilityLevel;
+
+// =============================================================================
+// Test Data
+// =============================================================================
+
+/// Small input: simple object with a few fields
+fn small_input() -> &'static str {
+    r#"name = "Alice"
+age = 30
+active = true
+"#
+}
+
+/// Medium input: nested structure with arrays
+fn medium_input() -> &'static str {
+    r#"$schema = "user.schema.eure"
+
+name = "Alice"
+email = "alice@example.com"
+age = 30
+active = true
+
+profile {
+    bio = "Software engineer"
+    location = "Tokyo"
+    website = "https://alice.dev"
+}
+
+tags[] = "rust"
+tags[] = "typescript"
+tags[] = "python"
+
+contacts[] {
+    type = "email"
+    value = "alice@work.com"
+    primary = true
+}
+contacts[] {
+    type = "phone"
+    value = "+1-555-1234"
+    primary = false
+}
+
+metadata {
+    created_at = "2024-01-15"
+    updated_at = "2024-06-20"
+    version = 3
+}
+"#
+}
+
+/// Large input: array with many elements using Eure section syntax
+fn large_input() -> String {
+    let mut s = String::new();
+    for i in 0..100 {
+        s.push_str(&format!(
+            r#"items[] {{
+    id = {i}
+    name = "Item {i}"
+    price = {price}
+    in_stock = {in_stock}
+    tags = ["tag-a", "tag-b", "tag-c"]
+}}
+"#,
+            i = i,
+            price = (i as f64) * 9.99,
+            in_stock = i % 2 == 0
+        ));
+    }
+    s
+}
+
+// =============================================================================
+// Manual Pipeline (no query system)
+// =============================================================================
+
+/// Manual pipeline: parse -> document -> json without query system overhead
+fn manual_pipeline(text: &str) -> serde_json::Value {
+    // Step 1: Parse to CST
+    let cst = parse_tolerant(text).cst();
+
+    // Step 2: CST to EureDocument
+    let doc = cst_to_document(text, &cst).expect("document construction should succeed");
+
+    // Step 3: EureDocument to JSON
+    document_to_value(&doc, &Config::default()).expect("json conversion should succeed")
+}
+
+/// Manual: parse only (Input -> CST)
+fn manual_parse_only(text: &str) -> Cst {
+    parse_tolerant(text).cst()
+}
+
+/// Manual: document only (CST -> EureDocument)
+fn manual_document_only(text: &str, cst: &Cst) -> EureDocument {
+    cst_to_document(text, cst).expect("document construction should succeed")
+}
+
+/// Manual: json only (EureDocument -> JSON)
+fn manual_json_only(doc: &EureDocument) -> serde_json::Value {
+    document_to_value(doc, &Config::default()).expect("json conversion should succeed")
+}
+
+// =============================================================================
+// Query Pipeline (with query system)
+// =============================================================================
+
+/// Query pipeline: parse -> document -> json via query runtime
+fn query_pipeline(text: &str) -> Arc<serde_json::Value> {
+    let runtime = build_runtime();
+    let file = TextFile::from_path(PathBuf::from("bench.eure"));
+    runtime.resolve_asset(
+        file.clone(),
+        TextFileContent(text.to_string()),
+        DurabilityLevel::Static,
+    );
+
+    runtime
+        .query(EureToJson::new(file, Config::default()))
+        .expect("query should succeed")
+}
+
+/// Query pipeline with pre-built runtime (measures query execution only, not setup)
+fn query_pipeline_with_runtime(
+    runtime: &query_flow::QueryRuntime,
+    file: &TextFile,
+) -> Arc<serde_json::Value> {
+    runtime
+        .query(EureToJson::new(file.clone(), Config::default()))
+        .expect("query should succeed")
+}
+
+// =============================================================================
+// Benchmarks
+// =============================================================================
+
+fn bench_full_pipeline(c: &mut Criterion) {
+    let mut group = c.benchmark_group("full_pipeline");
+
+    // Small input
+    let small = small_input();
+    group.bench_with_input(BenchmarkId::new("manual", "small"), &small, |b, input| {
+        b.iter(|| manual_pipeline(black_box(input)))
+    });
+    group.bench_with_input(BenchmarkId::new("query", "small"), &small, |b, input| {
+        b.iter(|| query_pipeline(black_box(input)))
+    });
+
+    // Medium input
+    let medium = medium_input();
+    group.bench_with_input(BenchmarkId::new("manual", "medium"), &medium, |b, input| {
+        b.iter(|| manual_pipeline(black_box(input)))
+    });
+    group.bench_with_input(BenchmarkId::new("query", "medium"), &medium, |b, input| {
+        b.iter(|| query_pipeline(black_box(input)))
+    });
+
+    // Large input
+    let large = large_input();
+    group.bench_with_input(
+        BenchmarkId::new("manual", "large"),
+        large.as_str(),
+        |b, input| b.iter(|| manual_pipeline(black_box(input))),
+    );
+    group.bench_with_input(
+        BenchmarkId::new("query", "large"),
+        large.as_str(),
+        |b, input| b.iter(|| query_pipeline(black_box(input))),
+    );
+
+    group.finish();
+}
+
+fn bench_query_reuse(c: &mut Criterion) {
+    let mut group = c.benchmark_group("query_reuse");
+
+    // This benchmark measures query execution with a pre-built runtime
+    // to isolate the query overhead from runtime construction
+
+    let small = small_input();
+    let runtime = build_runtime();
+    let file = TextFile::from_path(PathBuf::from("bench.eure"));
+    runtime.resolve_asset(
+        file.clone(),
+        TextFileContent(small.to_string()),
+        DurabilityLevel::Static,
+    );
+
+    group.bench_function("query_with_prebuilt_runtime/small", |b| {
+        b.iter(|| query_pipeline_with_runtime(black_box(&runtime), black_box(&file)))
+    });
+
+    // Compare with manual for same input
+    group.bench_function("manual/small", |b| {
+        b.iter(|| manual_pipeline(black_box(small)))
+    });
+
+    group.finish();
+}
+
+fn bench_parse_phase(c: &mut Criterion) {
+    let mut group = c.benchmark_group("parse_phase");
+
+    let small = small_input();
+    let medium = medium_input();
+    let large = large_input();
+
+    group.bench_with_input(BenchmarkId::new("manual", "small"), &small, |b, input| {
+        b.iter(|| manual_parse_only(black_box(input)))
+    });
+    group.bench_with_input(BenchmarkId::new("manual", "medium"), &medium, |b, input| {
+        b.iter(|| manual_parse_only(black_box(input)))
+    });
+    group.bench_with_input(
+        BenchmarkId::new("manual", "large"),
+        large.as_str(),
+        |b, input| b.iter(|| manual_parse_only(black_box(input))),
+    );
+
+    group.finish();
+}
+
+fn bench_document_phase(c: &mut Criterion) {
+    let mut group = c.benchmark_group("document_phase");
+
+    let small = small_input();
+    let small_cst = manual_parse_only(small);
+
+    let medium = medium_input();
+    let medium_cst = manual_parse_only(medium);
+
+    let large = large_input();
+    let large_cst = manual_parse_only(&large);
+
+    group.bench_function("manual/small", |b| {
+        b.iter(|| manual_document_only(black_box(small), black_box(&small_cst)))
+    });
+    group.bench_function("manual/medium", |b| {
+        b.iter(|| manual_document_only(black_box(medium), black_box(&medium_cst)))
+    });
+    group.bench_function("manual/large", |b| {
+        b.iter(|| manual_document_only(black_box(&large), black_box(&large_cst)))
+    });
+
+    group.finish();
+}
+
+fn bench_json_phase(c: &mut Criterion) {
+    let mut group = c.benchmark_group("json_phase");
+
+    let small = small_input();
+    let small_cst = manual_parse_only(small);
+    let small_doc = manual_document_only(small, &small_cst);
+
+    let medium = medium_input();
+    let medium_cst = manual_parse_only(medium);
+    let medium_doc = manual_document_only(medium, &medium_cst);
+
+    let large = large_input();
+    let large_cst = manual_parse_only(&large);
+    let large_doc = manual_document_only(&large, &large_cst);
+
+    group.bench_function("manual/small", |b| {
+        b.iter(|| manual_json_only(black_box(&small_doc)))
+    });
+    group.bench_function("manual/medium", |b| {
+        b.iter(|| manual_json_only(black_box(&medium_doc)))
+    });
+    group.bench_function("manual/large", |b| {
+        b.iter(|| manual_json_only(black_box(&large_doc)))
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_full_pipeline,
+    bench_query_reuse,
+    bench_parse_phase,
+    bench_document_phase,
+    bench_json_phase,
+);
+criterion_main!(benches);


### PR DESCRIPTION
Add criterion benchmarks to measure the overhead of the query-flow system
by comparing:
1. Query pipeline: Input -> CST -> EureDocument -> JSON via query runtime
2. Manual pipeline: Direct function calls without query system

Key findings from initial benchmarks:
- New runtime overhead: ~6.6x for small, ~2x for medium, ~1.16x for large inputs
- Query cache hit: ~43x faster than manual (660ns vs 28µs for small input)

Benchmarks include:
- full_pipeline: End-to-end conversion comparison
- query_reuse: Query execution with pre-built runtime (shows cache benefits)
- parse_phase: CST parsing performance
- document_phase: EureDocument construction performance
- json_phase: JSON conversion performance

Run with: cargo bench -p eure-json --bench conversion