### PR TITLE
Add proptest for Text type

### DIFF
--- a/crates/eure-document/src/text.rs
+++ b/crates/eure-document/src/text.rs
@@ -905,3 +905,693 @@ mod tests {
         }
     }
 }
+
+#[cfg(test)]
+mod proptests {
+    extern crate std;
+
+    use super::*;
+    use alloc::vec;
+    use proptest::prelude::*;
+    use std::format;
+    use std::string::String;
+    use std::vec::Vec;
+
+    // =========================================================================
+    // Strategy generators
+    // =========================================================================
+
+    /// Strategy for generating arbitrary Language values.
+    fn arb_language() -> impl Strategy<Value = Language> {
+        prop_oneof![
+            Just(Language::Plaintext),
+            Just(Language::Implicit),
+            // Common language tags
+            Just(Language::Other("rust".into())),
+            Just(Language::Other("sql".into())),
+            Just(Language::Other("python".into())),
+            Just(Language::Other("javascript".into())),
+            // Arbitrary language tags
+            "[a-z][a-z0-9_-]{0,15}".prop_map(|s| Language::Other(s.into())),
+        ]
+    }
+
+    /// Strategy for generating arbitrary SyntaxHint values.
+    fn arb_syntax_hint() -> impl Strategy<Value = SyntaxHint> {
+        prop_oneof![
+            // String variants
+            Just(SyntaxHint::Str),
+            Just(SyntaxHint::LitStr),
+            Just(SyntaxHint::LitStr1),
+            Just(SyntaxHint::LitStr2),
+            Just(SyntaxHint::LitStr3),
+            // Inline variants
+            Just(SyntaxHint::Inline),
+            Just(SyntaxHint::Inline1),
+            Just(SyntaxHint::Delim1),
+            Just(SyntaxHint::Delim2),
+            Just(SyntaxHint::Delim3),
+            // Block variants
+            Just(SyntaxHint::Block),
+            Just(SyntaxHint::Block3),
+            Just(SyntaxHint::Block4),
+            Just(SyntaxHint::Block5),
+            Just(SyntaxHint::Block6),
+        ]
+    }
+
+    /// Strategy for generating text content without control characters.
+    fn arb_text_content() -> impl Strategy<Value = String> {
+        // Printable ASCII and common Unicode, excluding null and other control chars
+        proptest::collection::vec(
+            prop_oneof![
+                // Printable ASCII
+                prop::char::range(' ', '~'),
+                // Some Unicode characters
+                Just('日'),
+                Just('本'),
+                Just('語'),
+                Just('α'),
+                Just('β'),
+                Just('γ'),
+                Just('é'),
+                Just('ñ'),
+                Just('ü'),
+            ],
+            0..100,
+        )
+        .prop_map(|chars| chars.into_iter().collect())
+    }
+
+    /// Strategy for generating text content that's valid for escaped strings.
+    /// Excludes characters that would need escaping for simpler testing.
+    fn arb_simple_text_content() -> impl Strategy<Value = String> {
+        proptest::collection::vec(
+            prop_oneof![
+                // Printable ASCII excluding backslash and quotes
+                prop::char::range(' ', '!'), // space and !
+                prop::char::range('#', '&'), // # $ % &
+                prop::char::range('(', '['), // ( through [
+                prop::char::range(']', '~'), // ] through ~
+            ],
+            0..50,
+        )
+        .prop_map(|chars| chars.into_iter().collect())
+    }
+
+    /// Strategy for single-line content (no newlines).
+    fn arb_single_line_content() -> impl Strategy<Value = String> {
+        proptest::collection::vec(
+            prop_oneof![
+                // Printable ASCII excluding newlines
+                prop::char::range(' ', '~'),
+            ],
+            0..50,
+        )
+        .prop_map(|chars| chars.into_iter().collect())
+    }
+
+    // =========================================================================
+    // Constructor tests
+    // =========================================================================
+
+    proptest! {
+        /// Text::plaintext should always set Language::Plaintext and SyntaxHint::Str.
+        #[test]
+        fn plaintext_constructor_sets_correct_fields(content in arb_text_content()) {
+            let text = Text::plaintext(content.clone());
+            prop_assert_eq!(text.content, content);
+            prop_assert_eq!(text.language, Language::Plaintext);
+            prop_assert_eq!(text.syntax_hint, Some(SyntaxHint::Str));
+        }
+
+        /// Text::inline_implicit should always set Language::Implicit and SyntaxHint::Inline1.
+        #[test]
+        fn inline_implicit_constructor_sets_correct_fields(content in arb_text_content()) {
+            let text = Text::inline_implicit(content.clone());
+            prop_assert_eq!(text.content, content);
+            prop_assert_eq!(text.language, Language::Implicit);
+            prop_assert_eq!(text.syntax_hint, Some(SyntaxHint::Inline1));
+        }
+
+        /// Text::inline should set Language from parameter and SyntaxHint::Inline1.
+        #[test]
+        fn inline_constructor_sets_correct_fields(
+            content in arb_text_content(),
+            lang in "[a-z][a-z0-9]{0,10}",
+        ) {
+            let text = Text::inline(content.clone(), lang.clone());
+            prop_assert_eq!(text.content, content);
+            prop_assert_eq!(text.language, Language::new(lang));
+            prop_assert_eq!(text.syntax_hint, Some(SyntaxHint::Inline1));
+        }
+
+        /// Text::block_implicit should add trailing newline if missing.
+        #[test]
+        fn block_implicit_adds_trailing_newline(content in arb_text_content()) {
+            let text = Text::block_implicit(content.clone());
+            prop_assert!(text.content.ends_with('\n'), "Block content should end with newline");
+            prop_assert_eq!(text.language, Language::Implicit);
+            prop_assert_eq!(text.syntax_hint, Some(SyntaxHint::Block3));
+        }
+
+        /// Text::block_implicit should not add extra newline if already present.
+        #[test]
+        fn block_implicit_no_double_newline(content in arb_text_content()) {
+            let content_with_newline = format!("{}\n", content);
+            let text = Text::block_implicit(content_with_newline.clone());
+            prop_assert_eq!(&text.content, &content_with_newline);
+            prop_assert!(!text.content.ends_with("\n\n") || content.ends_with('\n'),
+                "Should not add extra newline when already present");
+        }
+
+        /// Text::block should add trailing newline if missing.
+        #[test]
+        fn block_adds_trailing_newline(
+            content in arb_text_content(),
+            lang in "[a-z][a-z0-9]{0,10}",
+        ) {
+            let text = Text::block(content.clone(), lang.clone());
+            prop_assert!(text.content.ends_with('\n'), "Block content should end with newline");
+            prop_assert_eq!(text.language, Language::new(lang));
+            prop_assert_eq!(text.syntax_hint, Some(SyntaxHint::Block3));
+        }
+
+        /// Text::block_without_trailing_newline should preserve content exactly.
+        #[test]
+        fn block_without_trailing_newline_preserves_content(
+            content in arb_text_content(),
+            lang in "[a-z][a-z0-9]{0,10}",
+        ) {
+            let text = Text::block_without_trailing_newline(content.clone(), lang.clone());
+            prop_assert_eq!(text.content, content);
+            prop_assert_eq!(text.language, Language::new(lang));
+            prop_assert_eq!(text.syntax_hint, Some(SyntaxHint::Block3));
+        }
+
+        /// Text::new should not modify content.
+        #[test]
+        fn new_preserves_content(
+            content in arb_text_content(),
+            language in arb_language(),
+        ) {
+            let text = Text::new(content.clone(), language.clone());
+            prop_assert_eq!(text.content, content);
+            prop_assert_eq!(text.language, language);
+            prop_assert_eq!(text.syntax_hint, None);
+        }
+
+        /// Text::with_syntax_hint should add trailing newline for block hints.
+        #[test]
+        fn with_syntax_hint_adds_newline_for_block(
+            content in arb_text_content(),
+            language in arb_language(),
+            hint in prop_oneof![
+                Just(SyntaxHint::Block),
+                Just(SyntaxHint::Block3),
+                Just(SyntaxHint::Block4),
+                Just(SyntaxHint::Block5),
+                Just(SyntaxHint::Block6),
+            ],
+        ) {
+            let text = Text::with_syntax_hint(content.clone(), language.clone(), hint);
+            prop_assert!(text.content.ends_with('\n'), "Block content should end with newline");
+            prop_assert_eq!(text.language, language);
+            prop_assert_eq!(text.syntax_hint, Some(hint));
+        }
+
+        /// Text::with_syntax_hint should not modify content for non-block hints.
+        #[test]
+        fn with_syntax_hint_preserves_content_for_non_block(
+            content in arb_text_content(),
+            language in arb_language(),
+            hint in prop_oneof![
+                Just(SyntaxHint::Str),
+                Just(SyntaxHint::LitStr),
+                Just(SyntaxHint::Inline1),
+                Just(SyntaxHint::Delim1),
+            ],
+        ) {
+            let text = Text::with_syntax_hint(content.clone(), language.clone(), hint);
+            prop_assert_eq!(text.content, content);
+            prop_assert_eq!(text.language, language);
+            prop_assert_eq!(text.syntax_hint, Some(hint));
+        }
+    }
+
+    // =========================================================================
+    // Equality tests
+    // =========================================================================
+
+    proptest! {
+        /// PartialEq should ignore syntax_hint.
+        #[test]
+        fn equality_ignores_syntax_hint(
+            content in arb_text_content(),
+            language in arb_language(),
+            hint1 in arb_syntax_hint(),
+            hint2 in arb_syntax_hint(),
+        ) {
+            let text1 = Text {
+                content: content.clone(),
+                language: language.clone(),
+                syntax_hint: Some(hint1),
+            };
+            let text2 = Text {
+                content: content.clone(),
+                language: language.clone(),
+                syntax_hint: Some(hint2),
+            };
+            prop_assert_eq!(text1, text2, "Equality should ignore syntax_hint");
+        }
+
+        /// PartialEq should compare content.
+        #[test]
+        fn equality_compares_content(
+            content1 in arb_text_content(),
+            content2 in arb_text_content(),
+            language in arb_language(),
+        ) {
+            let text1 = Text::new(content1.clone(), language.clone());
+            let text2 = Text::new(content2.clone(), language.clone());
+            if content1 == content2 {
+                prop_assert_eq!(text1, text2);
+            } else {
+                prop_assert_ne!(text1, text2);
+            }
+        }
+
+        /// PartialEq should compare language.
+        #[test]
+        fn equality_compares_language(
+            content in arb_text_content(),
+            lang1 in arb_language(),
+            lang2 in arb_language(),
+        ) {
+            let text1 = Text::new(content.clone(), lang1.clone());
+            let text2 = Text::new(content.clone(), lang2.clone());
+            if lang1 == lang2 {
+                prop_assert_eq!(text1, text2);
+            } else {
+                prop_assert_ne!(text1, text2);
+            }
+        }
+    }
+
+    // =========================================================================
+    // Language tests
+    // =========================================================================
+
+    proptest! {
+        /// Language::new with "plaintext" or empty string should produce Plaintext.
+        #[test]
+        fn language_new_plaintext_variants(_dummy in Just(())) {
+            prop_assert_eq!(Language::new("plaintext"), Language::Plaintext);
+            prop_assert_eq!(Language::new(""), Language::Plaintext);
+        }
+
+        /// Language::new with other strings should produce Other.
+        #[test]
+        fn language_new_other(lang in "[a-z][a-z0-9]{1,15}") {
+            if lang != "plaintext" {
+                let result = Language::new(lang.clone());
+                prop_assert_eq!(result, Language::Other(lang.into()));
+            }
+        }
+
+        /// Language::Implicit is compatible with everything.
+        #[test]
+        fn implicit_is_compatible_with_all(lang in arb_language()) {
+            prop_assert!(Language::Implicit.is_compatible_with(&lang),
+                "Implicit should be compatible with {:?}", lang);
+        }
+
+        /// Everything is compatible with Language::Implicit.
+        #[test]
+        fn all_compatible_with_implicit(lang in arb_language()) {
+            prop_assert!(lang.is_compatible_with(&Language::Implicit),
+                "{:?} should be compatible with Implicit", lang);
+        }
+
+        /// Same languages are compatible with themselves.
+        #[test]
+        fn same_language_compatible(lang in arb_language()) {
+            prop_assert!(lang.is_compatible_with(&lang),
+                "{:?} should be compatible with itself", lang);
+        }
+
+        /// Language::as_str returns correct values.
+        #[test]
+        fn language_as_str_correct(lang in arb_language()) {
+            match &lang {
+                Language::Plaintext => prop_assert_eq!(lang.as_str(), Some("plaintext")),
+                Language::Implicit => prop_assert_eq!(lang.as_str(), None),
+                Language::Other(s) => prop_assert_eq!(lang.as_str(), Some(s.as_ref())),
+            }
+        }
+    }
+
+    // =========================================================================
+    // SyntaxHint tests
+    // =========================================================================
+
+    proptest! {
+        /// SyntaxHint classification methods are mutually exclusive (except Str which is both escaped and string).
+        #[test]
+        fn syntax_hint_classification_consistency(hint in arb_syntax_hint()) {
+            let is_str = hint.is_string();
+            let is_inline = hint.is_inline();
+            let is_block = hint.is_block();
+
+            // At most one category should be true (inline and block are mutually exclusive with string)
+            if is_inline {
+                prop_assert!(!is_str, "Inline hints should not be strings");
+                prop_assert!(!is_block, "Inline hints should not be blocks");
+            }
+            if is_block {
+                prop_assert!(!is_str, "Block hints should not be strings");
+                prop_assert!(!is_inline, "Block hints should not be inline");
+            }
+            if is_str {
+                prop_assert!(!is_inline, "String hints should not be inline");
+                prop_assert!(!is_block, "String hints should not be blocks");
+            }
+        }
+
+        /// Every SyntaxHint should belong to exactly one category.
+        #[test]
+        fn syntax_hint_belongs_to_one_category(hint in arb_syntax_hint()) {
+            let categories = [
+                hint.is_string(),
+                hint.is_inline(),
+                hint.is_block(),
+            ];
+            let count = categories.iter().filter(|&&b| b).count();
+            prop_assert_eq!(count, 1, "Each hint should belong to exactly one category: {:?}", hint);
+        }
+    }
+
+    // =========================================================================
+    // Parsing tests
+    // =========================================================================
+
+    proptest! {
+        /// Parsing simple content (no escapes) should round-trip through escape parsing.
+        #[test]
+        fn parse_quoted_string_simple_roundtrip(content in arb_simple_text_content()) {
+            let text = Text::parse_quoted_string(&content);
+            prop_assert!(text.is_ok(), "Failed to parse simple content: {:?}", content);
+            let text = text.unwrap();
+            prop_assert_eq!(text.content, content);
+            prop_assert_eq!(text.language, Language::Plaintext);
+        }
+
+        /// Escape sequences should be correctly decoded.
+        #[test]
+        fn parse_quoted_string_escape_sequences(_dummy in Just(())) {
+            let cases = [
+                ("\\n", "\n"),
+                ("\\r", "\r"),
+                ("\\t", "\t"),
+                ("\\0", "\0"),
+                ("\\\\", "\\"),
+                ("\\\"", "\""),
+                ("\\'", "'"),
+                ("\\u{0041}", "A"),
+                ("\\u{3042}", "あ"),
+            ];
+            for (input, expected) in cases {
+                let result = Text::parse_quoted_string(input);
+                prop_assert!(result.is_ok(), "Failed to parse: {:?}", input);
+                prop_assert_eq!(result.unwrap().content, expected, "Mismatch for: {:?}", input);
+            }
+        }
+
+        /// Invalid escape sequences should produce errors.
+        #[test]
+        fn parse_quoted_string_invalid_escape(c in prop::char::range('a', 'z').prop_filter(
+            "not a valid escape",
+            |c| !matches!(*c, 'n' | 'r' | 't' | '0' | 'u')
+        )) {
+            let input = format!("\\{}", c);
+            let result = Text::parse_quoted_string(&input);
+            prop_assert!(result.is_err(), "Should fail for invalid escape: {:?}", input);
+            match result {
+                Err(TextParseError::InvalidEscapeSequence(ch)) => {
+                    prop_assert_eq!(ch, c, "Error should report the invalid char");
+                }
+                other => {
+                    prop_assert!(false, "Expected InvalidEscapeSequence, got {:?}", other);
+                }
+            }
+        }
+
+        /// parse_text_binding should trim whitespace and strip trailing newline.
+        #[test]
+        fn parse_text_binding_trims_correctly(
+            leading_space in " {0,10}",
+            content in arb_single_line_content().prop_filter("no whitespace only", |s| !s.trim().is_empty()),
+            trailing_space in " {0,10}",
+        ) {
+            let input = format!("{}{}{}\n", leading_space, content, trailing_space);
+            let result = Text::parse_text_binding(&input);
+            prop_assert!(result.is_ok(), "Failed to parse: {:?}", input);
+            let text = result.unwrap();
+            prop_assert_eq!(text.content, content.trim());
+            prop_assert_eq!(text.language, Language::Plaintext);
+        }
+
+        /// parse_text_binding should not process escape sequences.
+        #[test]
+        fn parse_text_binding_preserves_backslashes(_dummy in Just(())) {
+            let inputs = [
+                ("\\n", "\\n"),
+                ("\\t", "\\t"),
+                ("C:\\Users\\test", "C:\\Users\\test"),
+                ("\\b\\w+\\b", "\\b\\w+\\b"),
+            ];
+            for (input, expected) in inputs {
+                let with_newline = format!("{}\n", input);
+                let result = Text::parse_text_binding(&with_newline);
+                prop_assert!(result.is_ok(), "Failed to parse: {:?}", input);
+                prop_assert_eq!(result.unwrap().content, expected);
+            }
+        }
+
+        /// parse_text_binding should reject content with embedded newlines.
+        #[test]
+        fn parse_text_binding_rejects_embedded_newlines(
+            before in arb_single_line_content(),
+            after in arb_single_line_content(),
+        ) {
+            let input = format!("{}\n{}\n", before, after);
+            let result = Text::parse_text_binding(&input);
+            prop_assert!(matches!(result, Err(TextParseError::NewlineInTextBinding)),
+                "Should reject embedded newlines: {:?}", input);
+        }
+
+        /// as_str should return the content.
+        #[test]
+        fn as_str_returns_content(content in arb_text_content(), language in arb_language()) {
+            let text = Text::new(content.clone(), language);
+            prop_assert_eq!(text.as_str(), content.as_str());
+        }
+    }
+
+    // =========================================================================
+    // parse_indented_block tests
+    // =========================================================================
+
+    proptest! {
+        /// parse_indented_block should correctly detect and remove base indentation.
+        #[test]
+        fn parse_indented_block_removes_base_indent(
+            // Use lines without leading/trailing whitespace; whitespace-only lines are treated specially
+            lines in proptest::collection::vec("[!-~]+", 1..10),
+            indent in 0usize..8,
+        ) {
+            // Build indented content with trailing indent marker
+            let indent_str: String = " ".repeat(indent);
+            let mut content = String::new();
+            for line in &lines {
+                content.push_str(&indent_str);
+                content.push_str(line);
+                content.push('\n');
+            }
+            // Add trailing indent for delimiter (without newline at end)
+            content.push_str(&indent_str);
+
+            let result = Text::parse_indented_block(
+                Language::Implicit,
+                content,
+                SyntaxHint::Block3,
+            );
+            prop_assert!(result.is_ok(), "Failed to parse indented block");
+            let text = result.unwrap();
+
+            // Verify each line had indent removed
+            let result_lines: Vec<&str> = text.content.lines().collect();
+            prop_assert_eq!(result_lines.len(), lines.len(),
+                "Line count should match: {:?} vs {:?}", result_lines, lines);
+            for (i, (result_line, orig_line)) in result_lines.iter().zip(lines.iter()).enumerate() {
+                prop_assert_eq!(*result_line, orig_line.as_str(),
+                    "Line {} should have indent removed", i);
+            }
+        }
+
+        /// parse_indented_block should preserve empty lines.
+        #[test]
+        fn parse_indented_block_preserves_empty_lines(
+            line1 in arb_single_line_content(),
+            line2 in arb_single_line_content(),
+            indent in 2usize..6,
+        ) {
+            let indent_str: String = " ".repeat(indent);
+            // Content with empty line in the middle
+            let content = format!(
+                "{}{}\n\n{}{}\n{}",
+                indent_str, line1,
+                indent_str, line2,
+                indent_str
+            );
+
+            let result = Text::parse_indented_block(
+                Language::Implicit,
+                content,
+                SyntaxHint::Block3,
+            );
+            prop_assert!(result.is_ok(), "Failed to parse");
+            let text = result.unwrap();
+
+            let expected = format!("{}\n\n{}\n", line1, line2);
+            prop_assert_eq!(text.content, expected);
+        }
+
+        /// parse_indented_block should return error for insufficient indent.
+        #[test]
+        fn parse_indented_block_error_on_insufficient_indent(
+            line1 in arb_single_line_content().prop_filter("non-empty", |s| !s.is_empty()),
+            // Line2 must not start with whitespace (we control indent via bad_str)
+            // and must have non-whitespace content
+            line2 in "[!-~]{1,20}",  // Non-whitespace printable ASCII
+            base_indent in 4usize..8,
+            bad_indent in 0usize..4,
+        ) {
+            prop_assume!(bad_indent < base_indent);
+            let base_str: String = " ".repeat(base_indent);
+            let bad_str: String = " ".repeat(bad_indent);
+
+            let content = format!(
+                "{}{}\n{}{}\n{}",
+                base_str, line1,
+                bad_str, line2,  // insufficient indent
+                base_str
+            );
+
+            let result = Text::parse_indented_block(
+                Language::Implicit,
+                content,
+                SyntaxHint::Block3,
+            );
+
+            match result {
+                Err(TextParseError::IndentError { line: 2, actual_indent, expected_indent }) => {
+                    prop_assert_eq!(actual_indent, bad_indent);
+                    prop_assert_eq!(expected_indent, base_indent);
+                }
+                other => {
+                    prop_assert!(false, "Expected IndentError for line 2, got {:?}", other);
+                }
+            }
+        }
+
+        /// parse_indented_block should handle zero indent correctly.
+        #[test]
+        fn parse_indented_block_zero_indent(lines in proptest::collection::vec("[!-~]+", 1..10)) {
+            let mut content = String::new();
+            for line in &lines {
+                content.push_str(line);
+                content.push('\n');
+            }
+            // No trailing indent
+
+            let result = Text::parse_indented_block(
+                Language::Other("test".into()),
+                content.clone(),
+                SyntaxHint::Block3,
+            );
+            prop_assert!(result.is_ok(), "Failed to parse zero-indent block");
+            let text = result.unwrap();
+
+            // Content should be preserved as-is
+            let expected_lines: Vec<&str> = lines.iter().map(|s| s.as_str()).collect();
+            let result_lines: Vec<&str> = text.content.lines().collect();
+            prop_assert_eq!(result_lines, expected_lines);
+        }
+
+        /// parse_indented_block should preserve language and syntax_hint.
+        #[test]
+        fn parse_indented_block_preserves_metadata(
+            line in arb_single_line_content(),
+            language in arb_language(),
+            hint in prop_oneof![
+                Just(SyntaxHint::Block3),
+                Just(SyntaxHint::Block4),
+                Just(SyntaxHint::Block5),
+                Just(SyntaxHint::Block6),
+            ],
+        ) {
+            let content = format!("{}\n", line);
+            let result = Text::parse_indented_block(language.clone(), content, hint);
+            prop_assert!(result.is_ok());
+            let text = result.unwrap();
+            prop_assert_eq!(text.language, language);
+            prop_assert_eq!(text.syntax_hint, Some(hint));
+        }
+    }
+
+    // =========================================================================
+    // Edge case tests
+    // =========================================================================
+
+    proptest! {
+        /// Empty content should be handled correctly by constructors.
+        #[test]
+        fn empty_content_handling(_dummy in Just(())) {
+            let text = Text::plaintext("");
+            prop_assert_eq!(text.content, "");
+
+            let text = Text::inline_implicit("");
+            prop_assert_eq!(text.content, "");
+
+            let text = Text::block_implicit("");
+            prop_assert_eq!(text.content, "\n"); // Should add newline
+
+            let text = Text::block("", "rust");
+            prop_assert_eq!(text.content, "\n"); // Should add newline
+        }
+
+        /// Unicode content should be preserved correctly.
+        #[test]
+        fn unicode_content_preserved(content in "[\u{0080}-\u{FFFF}]{1,50}") {
+            let text = Text::plaintext(content.clone());
+            prop_assert_eq!(&text.content, &content);
+
+            let text = Text::inline_implicit(content.clone());
+            prop_assert_eq!(&text.content, &content);
+        }
+
+        /// Text with only whitespace should be handled correctly.
+        #[test]
+        fn whitespace_only_content(spaces in " {1,20}") {
+            let text = Text::plaintext(spaces.clone());
+            prop_assert_eq!(&text.content, &spaces);
+
+            // parse_text_binding should trim to empty
+            let input = format!("{}\n", spaces);
+            let result = Text::parse_text_binding(&input);
+            prop_assert!(result.is_ok());
+            prop_assert_eq!(result.unwrap().content, "");
+        }
+    }
+}


### PR DESCRIPTION
Add comprehensive property-based tests for the Text type and related
types (Language, SyntaxHint). The tests cover:

- Constructor behavior (plaintext, inline, block variants)
- Block constructors adding trailing newlines
- PartialEq ignoring syntax_hint
- Language compatibility rules
- SyntaxHint classification consistency
- parse_quoted_string escape sequence handling
- parse_text_binding whitespace trimming and backslash preservation
- parse_indented_block indentation detection and removal

No bugs were found - the implementation is robust.

https://claude.ai/code/session_01Y1jrBWutZjB9CCpbiGSX4x