### PR TITLE
Add rustup target install for wasm32-unknown-unknown in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ clippy:
 	@cargo clippy -q --offline -- -D warnings && echo "clippy passed"
 
 eure-ls-wasm:
-	@cargo clippy -p eure-ls --target wasm32-unknown-unknown --offline -- -D warnings && echo "eure-ls-wasm passed"
+	@rustup target add wasm32-unknown-unknown && cargo clippy -p eure-ls --target wasm32-unknown-unknown --offline -- -D warnings && echo "eure-ls-wasm passed"
 
 test:
 	@if command -v cargo-nextest >/dev/null 2>&1; then cargo nextest run --all-targets --all-features --offline --show-progress none --status-level fail --final-status-level fail; else cargo test -q --all-targets --all-features; fi && echo "test passed"


### PR DESCRIPTION
Ensures the wasm target is installed before running eure-ls-wasm check,
making it easier for new developers to run `make check` without manual setup.

https://claude.ai/code/session_01MJTQGmRKor1rfJ3v6iegyX