### PR TITLE
Redesign IntoEure trait to support remote types

### DIFF
--- a/crates/eure-document/src/write.rs
+++ b/crates/eure-document/src/write.rs
@@ -38,22 +38,63 @@ pub enum WriteError {
 /// Types implementing this trait can be serialized into [`EureDocument`]
 /// via [`DocumentConstructor`].
 ///
-/// # Examples
+/// # Type Parameters
+///
+/// - `T`: The target type to write (defaults to `Self`)
+///
+/// When `T = Self` (the default), this is standard writing.
+/// When `T != Self`, `Self` acts as a "strategy" type for writing remote types.
+/// This follows the same pattern as `FromEure<'doc, T>`.
+///
+/// # Remote Type Support
+///
+/// The `T` parameter enables writing external crate types that can't implement
+/// `IntoEure` directly (due to Rust's orphan rule). Define a marker type and
+/// implement `IntoEure<RemoteType>` for it:
 ///
 /// ```ignore
-/// impl IntoEure for User {
-///     fn write_to(self, c: &mut DocumentConstructor) -> Result<(), WriteError> {
+/// struct DurationDef;
+///
+/// impl IntoEure<std::time::Duration> for DurationDef {
+///     type Error = WriteError;
+///     fn write_to(from: &std::time::Duration, c: &mut DocumentConstructor) -> Result<(), Self::Error> {
 ///         c.record(|rec| {
-///             rec.field("name", self.name)?;
-///             rec.field_optional("age", self.age)?;
+///             rec.field("secs", &from.as_secs())?;
+///             rec.field("nanos", &from.subsec_nanos())?;
 ///             Ok(())
 ///         })
 ///     }
 /// }
 /// ```
-pub trait IntoEure {
-    /// Write this value to the current node in the document constructor.
-    fn write_to(self, c: &mut DocumentConstructor) -> Result<(), WriteError>;
+///
+/// Container types (`Option<M>`, `Vec<M>`, etc.) automatically support remote types:
+/// if `M: IntoEure<T>`, then `Option<M>: IntoEure<Option<T>>`.
+///
+/// # Examples
+///
+/// ```ignore
+/// impl IntoEure for User {
+///     type Error = WriteError;
+///     fn write_to(from: &Self, c: &mut DocumentConstructor) -> Result<(), Self::Error> {
+///         c.record(|rec| {
+///             rec.field("name", &from.name)?;
+///             rec.field_optional("age", from.age.as_ref())?;
+///             Ok(())
+///         })
+///     }
+/// }
+/// ```
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` cannot be written to Eure document",
+    label = "this type does not implement `IntoEure`",
+    note = "consider adding `#[derive(IntoEure)]` to `{Self}`"
+)]
+pub trait IntoEure<T: ?Sized = Self> {
+    /// The error type returned by writing.
+    type Error;
+
+    /// Write a value of type T to the document constructor.
+    fn write_to(from: &T, c: &mut DocumentConstructor) -> Result<(), Self::Error>;
 }
 
 // ============================================================================
@@ -61,99 +102,121 @@ pub trait IntoEure {
 // ============================================================================
 
 impl IntoEure for bool {
-    fn write_to(self, c: &mut DocumentConstructor) -> Result<(), WriteError> {
-        c.bind_primitive(PrimitiveValue::Bool(self))?;
+    type Error = WriteError;
+    fn write_to(from: &Self, c: &mut DocumentConstructor) -> Result<(), Self::Error> {
+        c.bind_primitive(PrimitiveValue::Bool(*from))?;
         Ok(())
     }
 }
 
 impl IntoEure for i32 {
-    fn write_to(self, c: &mut DocumentConstructor) -> Result<(), WriteError> {
-        c.bind_primitive(PrimitiveValue::Integer(BigInt::from(self)))?;
+    type Error = WriteError;
+    fn write_to(from: &Self, c: &mut DocumentConstructor) -> Result<(), Self::Error> {
+        c.bind_primitive(PrimitiveValue::Integer(BigInt::from(*from)))?;
         Ok(())
     }
 }
 
 impl IntoEure for i64 {
-    fn write_to(self, c: &mut DocumentConstructor) -> Result<(), WriteError> {
-        c.bind_primitive(PrimitiveValue::Integer(BigInt::from(self)))?;
+    type Error = WriteError;
+    fn write_to(from: &Self, c: &mut DocumentConstructor) -> Result<(), Self::Error> {
+        c.bind_primitive(PrimitiveValue::Integer(BigInt::from(*from)))?;
         Ok(())
     }
 }
 
 impl IntoEure for u32 {
-    fn write_to(self, c: &mut DocumentConstructor) -> Result<(), WriteError> {
-        c.bind_primitive(PrimitiveValue::Integer(BigInt::from(self)))?;
+    type Error = WriteError;
+    fn write_to(from: &Self, c: &mut DocumentConstructor) -> Result<(), Self::Error> {
+        c.bind_primitive(PrimitiveValue::Integer(BigInt::from(*from)))?;
         Ok(())
     }
 }
 
 impl IntoEure for u64 {
-    fn write_to(self, c: &mut DocumentConstructor) -> Result<(), WriteError> {
-        c.bind_primitive(PrimitiveValue::Integer(BigInt::from(self)))?;
+    type Error = WriteError;
+    fn write_to(from: &Self, c: &mut DocumentConstructor) -> Result<(), Self::Error> {
+        c.bind_primitive(PrimitiveValue::Integer(BigInt::from(*from)))?;
         Ok(())
     }
 }
 
 impl IntoEure for usize {
-    fn write_to(self, c: &mut DocumentConstructor) -> Result<(), WriteError> {
-        c.bind_primitive(PrimitiveValue::Integer(BigInt::from(self)))?;
+    type Error = WriteError;
+    fn write_to(from: &Self, c: &mut DocumentConstructor) -> Result<(), Self::Error> {
+        c.bind_primitive(PrimitiveValue::Integer(BigInt::from(*from)))?;
         Ok(())
     }
 }
 
 impl IntoEure for f32 {
-    fn write_to(self, c: &mut DocumentConstructor) -> Result<(), WriteError> {
-        c.bind_primitive(PrimitiveValue::F32(self))?;
+    type Error = WriteError;
+    fn write_to(from: &Self, c: &mut DocumentConstructor) -> Result<(), Self::Error> {
+        c.bind_primitive(PrimitiveValue::F32(*from))?;
         Ok(())
     }
 }
 
 impl IntoEure for f64 {
-    fn write_to(self, c: &mut DocumentConstructor) -> Result<(), WriteError> {
-        c.bind_primitive(PrimitiveValue::F64(self))?;
+    type Error = WriteError;
+    fn write_to(from: &Self, c: &mut DocumentConstructor) -> Result<(), Self::Error> {
+        c.bind_primitive(PrimitiveValue::F64(*from))?;
         Ok(())
     }
 }
 
 impl IntoEure for BigInt {
-    fn write_to(self, c: &mut DocumentConstructor) -> Result<(), WriteError> {
-        c.bind_primitive(PrimitiveValue::Integer(self))?;
+    type Error = WriteError;
+    fn write_to(from: &Self, c: &mut DocumentConstructor) -> Result<(), Self::Error> {
+        c.bind_primitive(PrimitiveValue::Integer(from.clone()))?;
         Ok(())
     }
 }
 
 impl IntoEure for String {
-    fn write_to(self, c: &mut DocumentConstructor) -> Result<(), WriteError> {
-        c.bind_primitive(PrimitiveValue::Text(Text::plaintext(self)))?;
+    type Error = WriteError;
+    fn write_to(from: &Self, c: &mut DocumentConstructor) -> Result<(), Self::Error> {
+        c.bind_primitive(PrimitiveValue::Text(Text::plaintext(from.clone())))?;
+        Ok(())
+    }
+}
+
+impl IntoEure for str {
+    type Error = WriteError;
+    fn write_to(from: &Self, c: &mut DocumentConstructor) -> Result<(), Self::Error> {
+        c.bind_primitive(PrimitiveValue::Text(Text::plaintext(from)))?;
         Ok(())
     }
 }
 
 impl IntoEure for &str {
-    fn write_to(self, c: &mut DocumentConstructor) -> Result<(), WriteError> {
-        c.bind_primitive(PrimitiveValue::Text(Text::plaintext(self)))?;
+    type Error = WriteError;
+    fn write_to(from: &&str, c: &mut DocumentConstructor) -> Result<(), Self::Error> {
+        c.bind_primitive(PrimitiveValue::Text(Text::plaintext(*from)))?;
         Ok(())
     }
 }
 
 impl IntoEure for Text {
-    fn write_to(self, c: &mut DocumentConstructor) -> Result<(), WriteError> {
-        c.bind_primitive(PrimitiveValue::Text(self))?;
+    type Error = WriteError;
+    fn write_to(from: &Self, c: &mut DocumentConstructor) -> Result<(), Self::Error> {
+        c.bind_primitive(PrimitiveValue::Text(from.clone()))?;
         Ok(())
     }
 }
 
 impl IntoEure for PrimitiveValue {
-    fn write_to(self, c: &mut DocumentConstructor) -> Result<(), WriteError> {
-        c.bind_primitive(self)?;
+    type Error = WriteError;
+    fn write_to(from: &Self, c: &mut DocumentConstructor) -> Result<(), Self::Error> {
+        c.bind_primitive(from.clone())?;
         Ok(())
     }
 }
 
 impl IntoEure for Identifier {
-    fn write_to(self, c: &mut DocumentConstructor) -> Result<(), WriteError> {
-        c.bind_primitive(PrimitiveValue::Text(Text::plaintext(self.into_string())))?;
+    type Error = WriteError;
+    fn write_to(from: &Self, c: &mut DocumentConstructor) -> Result<(), Self::Error> {
+        c.bind_primitive(PrimitiveValue::Text(Text::plaintext(from.as_ref())))?;
         Ok(())
     }
 }
@@ -162,42 +225,73 @@ impl IntoEure for Identifier {
 // Collection implementations
 // ============================================================================
 
-impl<T: IntoEure> IntoEure for Vec<T> {
-    fn write_to(self, c: &mut DocumentConstructor) -> Result<(), WriteError> {
-        c.bind_empty_array()?;
-        for item in self {
-            let scope = c.begin_scope();
-            c.navigate(PathSegment::ArrayIndex(None))?;
-            item.write_to(c)?;
-            c.end_scope(scope)?;
-        }
-        Ok(())
-    }
-}
-
-impl<K, V> IntoEure for Map<K, V>
+/// `Vec<M>` writes `Vec<T>` using M's IntoEure implementation.
+///
+/// When `M = T`, this is standard `Vec<T>` writing.
+/// When `M ≠ T`, M acts as a strategy type for writing remote type T.
+#[diagnostic::do_not_recommend]
+impl<M, T> IntoEure<Vec<T>> for Vec<M>
 where
-    K: Into<ObjectKey>,
-    V: IntoEure,
+    M: IntoEure<T>,
+    M::Error: From<WriteError>,
 {
-    fn write_to(self, c: &mut DocumentConstructor) -> Result<(), WriteError> {
-        c.bind_empty_map()?;
-        for (key, value) in self {
+    type Error = M::Error;
+    fn write_to(from: &Vec<T>, c: &mut DocumentConstructor) -> Result<(), Self::Error> {
+        c.bind_empty_array()
+            .map_err(|e| M::Error::from(WriteError::from(e)))?;
+        for item in from {
             let scope = c.begin_scope();
-            c.navigate(PathSegment::Value(key.into()))?;
-            value.write_to(c)?;
-            c.end_scope(scope)?;
+            c.navigate(PathSegment::ArrayIndex(None))
+                .map_err(|e| M::Error::from(WriteError::from(e)))?;
+            M::write_to(item, c)?;
+            c.end_scope(scope)
+                .map_err(|e| M::Error::from(WriteError::from(e)))?;
         }
         Ok(())
     }
 }
 
-impl<T: IntoEure> IntoEure for Option<T> {
-    fn write_to(self, c: &mut DocumentConstructor) -> Result<(), WriteError> {
-        match self {
-            Some(value) => value.write_to(c),
+/// `Map<K, M>` writes `Map<K, T>` using M's IntoEure implementation.
+#[diagnostic::do_not_recommend]
+impl<K, M, T> IntoEure<Map<K, T>> for Map<K, M>
+where
+    K: Clone + Into<ObjectKey>,
+    M: IntoEure<T>,
+    M::Error: From<WriteError>,
+{
+    type Error = M::Error;
+    fn write_to(from: &Map<K, T>, c: &mut DocumentConstructor) -> Result<(), Self::Error> {
+        c.bind_empty_map()
+            .map_err(|e| M::Error::from(WriteError::from(e)))?;
+        for (key, value) in from {
+            let scope = c.begin_scope();
+            c.navigate(PathSegment::Value(key.clone().into()))
+                .map_err(|e| M::Error::from(WriteError::from(e)))?;
+            M::write_to(value, c)?;
+            c.end_scope(scope)
+                .map_err(|e| M::Error::from(WriteError::from(e)))?;
+        }
+        Ok(())
+    }
+}
+
+/// `Option<M>` writes `Option<T>` using M's IntoEure implementation.
+///
+/// When `M = T`, this is standard `Option<T>` writing.
+/// When `M ≠ T`, M acts as a strategy type for writing remote type T.
+#[diagnostic::do_not_recommend]
+impl<M, T> IntoEure<Option<T>> for Option<M>
+where
+    M: IntoEure<T>,
+    M::Error: From<WriteError>,
+{
+    type Error = M::Error;
+    fn write_to(from: &Option<T>, c: &mut DocumentConstructor) -> Result<(), Self::Error> {
+        match from {
+            Some(value) => M::write_to(value, c),
             None => {
-                c.bind_primitive(PrimitiveValue::Null)?;
+                c.bind_primitive(PrimitiveValue::Null)
+                    .map_err(|e| M::Error::from(WriteError::from(e)))?;
                 Ok(())
             }
         }
@@ -210,13 +304,15 @@ impl<T: IntoEure> IntoEure for Option<T> {
 
 macro_rules! impl_into_document_tuple {
     ($n:expr, $($idx:tt: $var:ident),+) => {
-        impl<$($var: IntoEure),+> IntoEure for ($($var,)+) {
-            fn write_to(self, c: &mut DocumentConstructor) -> Result<(), WriteError> {
+        #[diagnostic::do_not_recommend]
+        impl<$($var: IntoEure<Error = WriteError>),+> IntoEure for ($($var,)+) {
+            type Error = WriteError;
+            fn write_to(from: &Self, c: &mut DocumentConstructor) -> Result<(), Self::Error> {
                 c.bind_empty_tuple()?;
                 $(
                     let scope = c.begin_scope();
                     c.navigate(PathSegment::TupleIndex($idx))?;
-                    self.$idx.write_to(c)?;
+                    $var::write_to(&from.$idx, c)?;
                     c.end_scope(scope)?;
                 )+
                 Ok(())
@@ -253,14 +349,14 @@ impl DocumentConstructor {
     ///
     /// ```ignore
     /// c.record(|rec| {
-    ///     rec.field("name", "Alice")?;
-    ///     rec.field("age", 30)?;
+    ///     rec.field("name", &"Alice")?;
+    ///     rec.field("age", &30)?;
     ///     Ok(())
     /// })?;
     /// ```
-    pub fn record<F, T>(&mut self, f: F) -> Result<T, WriteError>
+    pub fn record<F, R>(&mut self, f: F) -> Result<R, WriteError>
     where
-        F: FnOnce(&mut RecordWriter<'_>) -> Result<T, WriteError>,
+        F: FnOnce(&mut RecordWriter<'_>) -> Result<R, WriteError>,
     {
         self.bind_empty_map()?;
         let mut writer = RecordWriter::new(self);
@@ -273,15 +369,15 @@ impl DocumentConstructor {
     ///
     /// ```ignore
     /// c.tuple(|t| {
-    ///     t.next("first")?;
-    ///     t.next(42)?;
-    ///     t.next(true)?;
+    ///     t.next(&"first")?;
+    ///     t.next(&42)?;
+    ///     t.next(&true)?;
     ///     Ok(())
     /// })?;
     /// ```
-    pub fn tuple<F, T>(&mut self, f: F) -> Result<T, WriteError>
+    pub fn tuple<F, R>(&mut self, f: F) -> Result<R, WriteError>
     where
-        F: FnOnce(&mut TupleWriter<'_>) -> Result<T, WriteError>,
+        F: FnOnce(&mut TupleWriter<'_>) -> Result<R, WriteError>,
     {
         self.bind_empty_tuple()?;
         let mut writer = TupleWriter::new(self);
@@ -293,16 +389,47 @@ impl DocumentConstructor {
     /// # Example
     ///
     /// ```ignore
-    /// c.set_extension("optional", true)?;
+    /// c.set_extension("optional", &true)?;
     /// ```
-    pub fn set_extension<T: IntoEure>(&mut self, name: &str, value: T) -> Result<(), WriteError> {
+    pub fn set_extension<T: IntoEure<Error = WriteError> + ?Sized>(
+        &mut self,
+        name: &str,
+        value: &T,
+    ) -> Result<(), WriteError> {
         let ident: Identifier = name
             .parse()
             .map_err(|_| WriteError::InvalidIdentifier(name.into()))?;
         let scope = self.begin_scope();
         self.navigate(PathSegment::Extension(ident))?;
-        value.write_to(self)?;
+        T::write_to(value, self)?;
         self.end_scope(scope)?;
+        Ok(())
+    }
+
+    /// Set an extension value on the current node using a marker/strategy type.
+    ///
+    /// This is used for writing remote types where `M` implements
+    /// `IntoEure<T>` but `T` doesn't implement `IntoEure` itself.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// c.set_extension_via::<DurationDef, _>("timeout", &duration)?;
+    /// ```
+    pub fn set_extension_via<M, T>(&mut self, name: &str, value: &T) -> Result<(), M::Error>
+    where
+        M: IntoEure<T>,
+        M::Error: From<WriteError>,
+    {
+        let ident: Identifier = name
+            .parse()
+            .map_err(|_| M::Error::from(WriteError::InvalidIdentifier(name.into())))?;
+        let scope = self.begin_scope();
+        self.navigate(PathSegment::Extension(ident))
+            .map_err(|e| M::Error::from(WriteError::from(e)))?;
+        M::write_to(value, self)?;
+        self.end_scope(scope)
+            .map_err(|e| M::Error::from(WriteError::from(e)))?;
         Ok(())
     }
 
@@ -312,15 +439,38 @@ impl DocumentConstructor {
     /// # Example
     ///
     /// ```ignore
-    /// c.set_extension_optional("default", self.default)?;
+    /// c.set_extension_optional("default", self.default.as_ref())?;
     /// ```
-    pub fn set_extension_optional<T: IntoEure>(
+    pub fn set_extension_optional<T: IntoEure<Error = WriteError>>(
         &mut self,
         name: &str,
-        value: Option<T>,
+        value: Option<&T>,
     ) -> Result<(), WriteError> {
         if let Some(v) = value {
             self.set_extension(name, v)?;
+        }
+        Ok(())
+    }
+
+    /// Set an optional extension value on the current node using a marker/strategy type.
+    /// Does nothing if the value is `None`.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// c.set_extension_optional_via::<DurationDef, _>("timeout", self.timeout.as_ref())?;
+    /// ```
+    pub fn set_extension_optional_via<M, T>(
+        &mut self,
+        name: &str,
+        value: Option<&T>,
+    ) -> Result<(), M::Error>
+    where
+        M: IntoEure<T>,
+        M::Error: From<WriteError>,
+    {
+        if let Some(v) = value {
+            self.set_extension_via::<M, T>(name, v)?;
         }
         Ok(())
     }
@@ -333,7 +483,7 @@ impl DocumentConstructor {
     /// match self {
     ///     MyEnum::Foo(inner) => {
     ///         c.set_variant("foo")?;
-    ///         inner.write_to(c)?;
+    ///         str::write_to(inner, c)?;
     ///     }
     /// }
     /// ```
@@ -346,10 +496,27 @@ impl DocumentConstructor {
     /// # Example
     ///
     /// ```ignore
-    /// c.write(my_value)?;
+    /// c.write(&my_value)?;
     /// ```
-    pub fn write<T: IntoEure>(&mut self, value: T) -> Result<(), WriteError> {
-        value.write_to(self)
+    pub fn write<T: IntoEure<Error = WriteError>>(&mut self, value: &T) -> Result<(), WriteError> {
+        T::write_to(value, self)
+    }
+
+    /// Write a value to the current node using a marker/strategy type.
+    ///
+    /// This is used for writing remote types where `M` implements
+    /// `IntoEure<T>` but `T` doesn't implement `IntoEure` itself.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// c.write_via::<DurationDef, _>(&duration)?;
+    /// ```
+    pub fn write_via<M, T>(&mut self, value: &T) -> Result<(), M::Error>
+    where
+        M: IntoEure<T>,
+    {
+        M::write_to(value, self)
     }
 }
 
@@ -360,7 +527,7 @@ mod tests {
     #[test]
     fn test_primitive_bool() {
         let mut c = DocumentConstructor::new();
-        true.write_to(&mut c).unwrap();
+        bool::write_to(&true, &mut c).unwrap();
         let doc = c.finish();
         assert_eq!(
             doc.root().content,
@@ -371,7 +538,7 @@ mod tests {
     #[test]
     fn test_primitive_string() {
         let mut c = DocumentConstructor::new();
-        "hello".write_to(&mut c).unwrap();
+        str::write_to("hello", &mut c).unwrap();
         let doc = c.finish();
         assert_eq!(
             doc.root().content,
@@ -382,7 +549,7 @@ mod tests {
     #[test]
     fn test_vec() {
         let mut c = DocumentConstructor::new();
-        vec![1i32, 2, 3].write_to(&mut c).unwrap();
+        <Vec<i32>>::write_to(&vec![1i32, 2, 3], &mut c).unwrap();
         let doc = c.finish();
         let arr = doc.root().as_array().unwrap();
         assert_eq!(arr.len(), 3);
@@ -391,7 +558,7 @@ mod tests {
     #[test]
     fn test_tuple() {
         let mut c = DocumentConstructor::new();
-        (1i32, "two", true).write_to(&mut c).unwrap();
+        <(i32, &str, bool)>::write_to(&(1i32, "two", true), &mut c).unwrap();
         let doc = c.finish();
         let tuple = doc.root().as_tuple().unwrap();
         assert_eq!(tuple.len(), 3);
@@ -401,8 +568,8 @@ mod tests {
     fn test_record() {
         let mut c = DocumentConstructor::new();
         c.record(|rec| {
-            rec.field("name", "Alice")?;
-            rec.field("age", 30i32)?;
+            rec.field("name", &"Alice")?;
+            rec.field("age", &30i32)?;
             Ok(())
         })
         .unwrap();
@@ -415,11 +582,11 @@ mod tests {
     fn test_set_extension() {
         let mut c = DocumentConstructor::new();
         c.record(|rec| {
-            rec.field("type", "string")?;
+            rec.field("type", &"string")?;
             Ok(())
         })
         .unwrap();
-        c.set_extension("optional", true).unwrap();
+        c.set_extension("optional", &true).unwrap();
         let doc = c.finish();
 
         let root = doc.root();
@@ -434,7 +601,7 @@ mod tests {
         let mut c = DocumentConstructor::new();
         c.set_variant("foo").unwrap();
         c.record(|rec| {
-            rec.field("value", 42i32)?;
+            rec.field("value", &42i32)?;
             Ok(())
         })
         .unwrap();
@@ -451,11 +618,11 @@ mod tests {
     fn test_nested_record() {
         let mut c = DocumentConstructor::new();
         c.record(|rec| {
-            rec.field("name", "Alice")?;
+            rec.field("name", &"Alice")?;
             rec.field_with("address", |c| {
                 c.record(|rec| {
-                    rec.field("city", "Tokyo")?;
-                    rec.field("zip", "100-0001")?;
+                    rec.field("city", &"Tokyo")?;
+                    rec.field("zip", &"100-0001")?;
                     Ok(())
                 })
             })?;
@@ -465,5 +632,160 @@ mod tests {
         let doc = c.finish();
         let map = doc.root().as_map().unwrap();
         assert_eq!(map.len(), 2);
+    }
+
+    // =========================================================================
+    // Remote type support tests
+    // =========================================================================
+
+    /// A "remote" type that we can't implement IntoEure for directly.
+    #[derive(Debug, PartialEq)]
+    struct RemoteDuration {
+        secs: u64,
+        nanos: u32,
+    }
+
+    /// Marker type that implements IntoEure<RemoteDuration>.
+    struct RemoteDurationDef;
+
+    impl IntoEure<RemoteDuration> for RemoteDurationDef {
+        type Error = WriteError;
+
+        fn write_to(from: &RemoteDuration, c: &mut DocumentConstructor) -> Result<(), Self::Error> {
+            c.record(|rec| {
+                rec.field("secs", &from.secs)?;
+                rec.field("nanos", &from.nanos)?;
+                Ok(())
+            })
+        }
+    }
+
+    #[test]
+    fn test_remote_type_basic_writing() {
+        let duration = RemoteDuration {
+            secs: 10,
+            nanos: 500,
+        };
+        let mut c = DocumentConstructor::new();
+        c.write_via::<RemoteDurationDef, _>(&duration).unwrap();
+        let doc = c.finish();
+
+        let map = doc.root().as_map().unwrap();
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn test_remote_type_in_vec() {
+        let durations = vec![
+            RemoteDuration { secs: 1, nanos: 0 },
+            RemoteDuration {
+                secs: 2,
+                nanos: 100,
+            },
+        ];
+        let mut c = DocumentConstructor::new();
+        c.write_via::<Vec<RemoteDurationDef>, _>(&durations)
+            .unwrap();
+        let doc = c.finish();
+
+        let arr = doc.root().as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+    }
+
+    #[test]
+    fn test_remote_type_in_option_some() {
+        let duration = Some(RemoteDuration { secs: 5, nanos: 0 });
+        let mut c = DocumentConstructor::new();
+        c.write_via::<Option<RemoteDurationDef>, _>(&duration)
+            .unwrap();
+        let doc = c.finish();
+
+        let map = doc.root().as_map().unwrap();
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn test_remote_type_in_option_none() {
+        let duration: Option<RemoteDuration> = None;
+        let mut c = DocumentConstructor::new();
+        c.write_via::<Option<RemoteDurationDef>, _>(&duration)
+            .unwrap();
+        let doc = c.finish();
+
+        assert_eq!(
+            doc.root().content,
+            NodeValue::Primitive(PrimitiveValue::Null)
+        );
+    }
+
+    #[test]
+    fn test_field_via() {
+        let duration = RemoteDuration { secs: 30, nanos: 0 };
+        let mut c = DocumentConstructor::new();
+        c.record(|rec| {
+            rec.field("name", &"test")?;
+            rec.field_via::<RemoteDurationDef, _>("timeout", &duration)?;
+            Ok(())
+        })
+        .unwrap();
+        let doc = c.finish();
+
+        let map = doc.root().as_map().unwrap();
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn test_field_optional_via_some() {
+        let duration = Some(RemoteDuration { secs: 60, nanos: 0 });
+        let mut c = DocumentConstructor::new();
+        c.record(|rec| {
+            rec.field("name", &"test")?;
+            rec.field_optional_via::<RemoteDurationDef, _>("timeout", duration.as_ref())?;
+            Ok(())
+        })
+        .unwrap();
+        let doc = c.finish();
+
+        let map = doc.root().as_map().unwrap();
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn test_field_optional_via_none() {
+        let duration: Option<RemoteDuration> = None;
+        let mut c = DocumentConstructor::new();
+        c.record(|rec| {
+            rec.field("name", &"test")?;
+            rec.field_optional_via::<RemoteDurationDef, _>("timeout", duration.as_ref())?;
+            Ok(())
+        })
+        .unwrap();
+        let doc = c.finish();
+
+        let map = doc.root().as_map().unwrap();
+        assert_eq!(map.len(), 1); // Only "name", no "timeout"
+    }
+
+    #[test]
+    fn test_set_extension_via() {
+        let duration = RemoteDuration {
+            secs: 120,
+            nanos: 0,
+        };
+        let mut c = DocumentConstructor::new();
+        c.record(|rec| {
+            rec.field("value", &42i32)?;
+            Ok(())
+        })
+        .unwrap();
+        c.set_extension_via::<RemoteDurationDef, _>("timeout", &duration)
+            .unwrap();
+        let doc = c.finish();
+
+        let root = doc.root();
+        assert!(
+            root.extensions
+                .contains_key(&"timeout".parse::<Identifier>().unwrap())
+        );
     }
 }


### PR DESCRIPTION
Change IntoEure trait to IntoEure<T: ?Sized = Self> with fn write_to(from: &T, ...)
to mirror FromEure pattern. This enables:
- Remote type support via marker/strategy types (same pattern as FromEure)
- Derive macro compatibility for proxy/opaque types

Changes:
- Add type parameter T with Self default to IntoEure trait
- Change write_to to take &T instead of &Self
- Add _via methods to DocumentConstructor (write_via, set_extension_via,
  set_extension_optional_via)
- Add _via methods to RecordWriter (field_via, field_optional_via)
- Add _via methods to TupleWriter (next_via)
- Add ?Sized bounds to support str type
- Add impl IntoEure for &str for convenient string literal usage
- Update container implementations (Vec, Option, Map) for marker type support

https://claude.ai/code/session_01RwRYZWfptD8Mtf6dkNzUAw