### PR TITLE
Schema-guided and variant-aware JSON→Eure conversion (CLI + library)

### DIFF
--- a/crates/eure-cli/src/commands/from_json.rs
+++ b/crates/eure-cli/src/commands/from_json.rs
@@ -1,19 +1,27 @@
-use eure::query::{TextFile, TextFileContent, build_runtime};
+use eure::query::{DocumentToSchemaQuery, TextFile, TextFileContent, build_runtime};
 use eure::query_flow::DurabilityLevel;
-use eure_json::{Config as JsonConfig, JsonToEure};
+use eure_json::value_to_document_with_variant_repr;
 use eure_document::document::EureDocument;
 use eure_document::source::{EureSource, SourceDocument};
 use eure_schema::interop::VariantRepr;
+use eure_schema::{SchemaDocument, SchemaNodeContent};
 
-use crate::util::{VariantFormat, display_path, handle_query_error, read_input};
+use crate::util::{VariantFormat, read_input};
 
 #[derive(clap::Args)]
 pub struct Args {
     /// Path to JSON file to convert (use - for stdin)
     pub file: String,
+    /// Optional schema file used to infer union variant representation (`$interop.variant-repr`)
+    #[arg(short, long)]
+    pub schema: Option<String>,
     /// Variant representation format
-    #[arg(short = 'v', long, value_enum, default_value = "external")]
-    pub variant: VariantFormat,
+    ///
+    /// If omitted:
+    /// - with `--schema`: inferred from schema root union interop (falls back to untagged)
+    /// - without `--schema`: defaults to untagged
+    #[arg(short = 'v', long, value_enum)]
+    pub variant: Option<VariantFormat>,
     /// Tag field name for internal/adjacent representations
     #[arg(short = 't', long, default_value = "type")]
     pub tag: String,
@@ -40,36 +48,36 @@ pub fn run(args: Args) {
     // 2. Create query runtime
     let runtime = build_runtime();
 
-    // 3. Register JSON file as asset
-    let file = TextFile::from_path(display_path(file_opt).into());
-    runtime.resolve_asset(
-        file.clone(),
-        TextFileContent(contents),
-        DurabilityLevel::Static,
-    );
-
-    // 4. Configure variant representation
-    let variant_repr = match args.variant {
-        VariantFormat::External => VariantRepr::External,
-        VariantFormat::Internal => VariantRepr::Internal { tag: args.tag },
-        VariantFormat::Adjacent => VariantRepr::Adjacent {
-            tag: args.tag,
-            content: args.content,
-        },
-        VariantFormat::Untagged => VariantRepr::Untagged,
+    // 3. Determine variant representation
+    let variant_repr = if let Some(explicit) = args.variant.clone() {
+        variant_format_to_repr(explicit, args.tag.clone(), args.content.clone())
+    } else if let Some(schema_path) = args.schema.as_deref() {
+        let schema_repr = load_schema_variant_repr(&runtime, schema_path);
+        schema_repr.unwrap_or(VariantRepr::Untagged)
+    } else {
+        VariantRepr::Untagged
     };
-    let config = JsonConfig { variant_repr };
 
-    // 5. Execute query to convert JSON to EureDocument
-    let document = match runtime.query(JsonToEure::new(file.clone(), config)) {
+    // 4. Convert JSON to EureDocument (schema/CLI-guided variant representation)
+    let json_value: serde_json::Value = match serde_json::from_str(&contents) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Error parsing JSON: {e}");
+            std::process::exit(1);
+        }
+    };
+    let document = match value_to_document_with_variant_repr(&json_value, &variant_repr) {
         Ok(doc) => doc,
-        Err(e) => handle_query_error(e),
+        Err(e) => {
+            eprintln!("Error converting JSON to Eure: {e}");
+            std::process::exit(1);
+        }
     };
 
-    // 6. Build minimal SourceDocument for formatting
-    let source_doc = build_minimal_source_document(document);
+    // 5. Build minimal SourceDocument for formatting
+    let source_doc = build_minimal_source_document(std::sync::Arc::new(document));
 
-    // 7. Format and output
+    // 6. Format and output
     let output = eure_fmt::format_source_document(&source_doc);
     println!("{output}");
 }
@@ -84,4 +92,49 @@ fn build_minimal_source_document(document: std::sync::Arc<EureDocument>) -> Sour
     };
 
     SourceDocument::new(doc, vec![root_source])
+}
+
+fn variant_format_to_repr(format: VariantFormat, tag: String, content: String) -> VariantRepr {
+    match format {
+        VariantFormat::External => VariantRepr::External,
+        VariantFormat::Internal => VariantRepr::Internal { tag },
+        VariantFormat::Adjacent => VariantRepr::Adjacent { tag, content },
+        VariantFormat::Untagged => VariantRepr::Untagged,
+    }
+}
+
+fn load_schema_variant_repr(
+    runtime: &eure::query_flow::QueryRuntime,
+    schema_path: &str,
+) -> Option<VariantRepr> {
+    let schema_file = TextFile::from_path(schema_path.into());
+    let schema_contents = match std::fs::read_to_string(schema_path) {
+        Ok(content) => content,
+        Err(e) => {
+            eprintln!("Error reading schema file: {e}");
+            std::process::exit(1);
+        }
+    };
+    runtime.resolve_asset(
+        schema_file.clone(),
+        TextFileContent(schema_contents),
+        DurabilityLevel::Static,
+    );
+
+    let validated = match runtime.query(DocumentToSchemaQuery::new(schema_file)) {
+        Ok(schema) => schema,
+        Err(e) => {
+            eprintln!("Error loading schema: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    root_union_variant_repr(&validated.schema)
+}
+
+fn root_union_variant_repr(schema: &SchemaDocument) -> Option<VariantRepr> {
+    match &schema.node(schema.root).content {
+        SchemaNodeContent::Union(union) => union.interop.variant_repr.clone(),
+        _ => None,
+    }
 }

--- a/crates/eure-json/src/lib.rs
+++ b/crates/eure-json/src/lib.rs
@@ -13,6 +13,7 @@ use eure::report::{ErrorReport, ErrorReports, Origin, OriginHints};
 use eure::tree::{Cst, InputSpan};
 use eure::value::{ObjectKey, PrimitiveValue};
 use eure_document::text::Text;
+use eure_document::parse::union::VARIANT;
 use eure_schema::interop::VariantRepr;
 use num_bigint::BigInt;
 use query_flow::{Db, QueryError, query};
@@ -338,6 +339,20 @@ pub fn value_to_document(
     Ok(doc)
 }
 
+/// Convert a JSON value to an EureDocument with explicit variant representation decoding.
+///
+/// Unlike [`value_to_document`], this function attempts to reconstruct `$variant`
+/// extensions from JSON objects according to `variant_repr`.
+pub fn value_to_document_with_variant_repr(
+    value: &JsonValue,
+    variant_repr: &VariantRepr,
+) -> Result<EureDocument, JsonToEureError> {
+    let mut doc = EureDocument::new();
+    let root_id = doc.get_root_id();
+    convert_json_to_node_with_variant_repr(&mut doc, root_id, value, variant_repr);
+    Ok(doc)
+}
+
 /// Convert a JSON value and set it as the content of the given node.
 fn convert_json_to_node(doc: &mut EureDocument, node_id: NodeId, value: &JsonValue) {
     match value {
@@ -382,6 +397,137 @@ fn convert_json_to_node(doc: &mut EureDocument, node_id: NodeId, value: &JsonVal
                 }
             }
         }
+    }
+}
+
+fn convert_json_to_node_with_variant_repr(
+    doc: &mut EureDocument,
+    node_id: NodeId,
+    value: &JsonValue,
+    variant_repr: &VariantRepr,
+) {
+    if let Some(decoded) = detect_variant(value, variant_repr) {
+        match &decoded.content {
+            DecodedVariantContent::Borrowed(content) => {
+                convert_json_to_node(doc, node_id, content);
+            }
+            DecodedVariantContent::Owned(content) => {
+                convert_json_to_node(doc, node_id, content);
+            }
+        }
+        let variant_id = doc.create_node(NodeValue::Primitive(PrimitiveValue::Text(
+            Text::plaintext(decoded.variant_name),
+        )));
+        doc.node_mut(node_id).extensions.insert(VARIANT, variant_id);
+        return;
+    }
+
+    match value {
+        JsonValue::Null => {
+            doc.node_mut(node_id).content = NodeValue::Primitive(PrimitiveValue::Null);
+        }
+        JsonValue::Bool(b) => {
+            doc.node_mut(node_id).content = NodeValue::Primitive(PrimitiveValue::Bool(*b));
+        }
+        JsonValue::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                doc.node_mut(node_id).content =
+                    NodeValue::Primitive(PrimitiveValue::Integer(BigInt::from(i)));
+            } else if let Some(u) = n.as_u64() {
+                doc.node_mut(node_id).content =
+                    NodeValue::Primitive(PrimitiveValue::Integer(BigInt::from(u)));
+            } else if let Some(f) = n.as_f64() {
+                doc.node_mut(node_id).content = NodeValue::Primitive(PrimitiveValue::F64(f));
+            }
+        }
+        JsonValue::String(s) => {
+            doc.node_mut(node_id).content =
+                NodeValue::Primitive(PrimitiveValue::Text(Text::plaintext(s.clone())));
+        }
+        JsonValue::Array(arr) => {
+            doc.node_mut(node_id).content = NodeValue::empty_array();
+            for item in arr {
+                let child_id = doc.create_node(NodeValue::hole());
+                convert_json_to_node_with_variant_repr(doc, child_id, item, variant_repr);
+                if let NodeValue::Array(ref mut array) = doc.node_mut(node_id).content {
+                    let _ = array.push(child_id);
+                }
+            }
+        }
+        JsonValue::Object(obj) => {
+            doc.node_mut(node_id).content = NodeValue::empty_map();
+            for (key, val) in obj {
+                let child_id = doc.create_node(NodeValue::hole());
+                convert_json_to_node_with_variant_repr(doc, child_id, val, variant_repr);
+                if let NodeValue::Map(ref mut map) = doc.node_mut(node_id).content {
+                    map.insert(ObjectKey::String(key.clone()), child_id);
+                }
+            }
+        }
+    }
+}
+
+enum DecodedVariantContent<'a> {
+    Borrowed(&'a JsonValue),
+    Owned(JsonValue),
+}
+
+struct DecodedVariant<'a> {
+    variant_name: String,
+    content: DecodedVariantContent<'a>,
+}
+
+fn detect_variant<'a>(value: &'a JsonValue, variant_repr: &VariantRepr) -> Option<DecodedVariant<'a>> {
+    let JsonValue::Object(obj) = value else {
+        return None;
+    };
+
+    match variant_repr {
+        VariantRepr::External => {
+            if obj.len() != 1 {
+                return None;
+            }
+            let (variant_name, content) = obj.iter().next()?;
+            Some(DecodedVariant {
+                variant_name: variant_name.clone(),
+                content: DecodedVariantContent::Borrowed(content),
+            })
+        }
+        VariantRepr::Internal { tag } => {
+            let tag_value = obj.get(tag)?;
+            let JsonValue::String(variant_name) = tag_value else {
+                return None;
+            };
+
+            let mut map = serde_json::Map::new();
+            for (k, v) in obj {
+                if k != tag {
+                    map.insert(k.clone(), v.clone());
+                }
+            }
+            Some(DecodedVariant {
+                variant_name: variant_name.clone(),
+                content: DecodedVariantContent::Owned(JsonValue::Object(map)),
+            })
+        }
+        VariantRepr::Adjacent { tag, content } => {
+            if tag == content {
+                return None;
+            }
+            let tag_value = obj.get(tag)?;
+            let JsonValue::String(variant_name) = tag_value else {
+                return None;
+            };
+            let content_value = obj.get(content)?;
+            if obj.len() != 2 {
+                return None;
+            }
+            Some(DecodedVariant {
+                variant_name: variant_name.clone(),
+                content: DecodedVariantContent::Borrowed(content_value),
+            })
+        }
+        VariantRepr::Untagged => None,
     }
 }
 
@@ -696,6 +842,61 @@ mod tests {
         });
         assert_eq!(
             value_to_document(&json, &Config::default()).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_json_to_eure_with_variant_repr_external() {
+        let json = json!({"Success": {"value": 42}});
+        let expected = eure!({
+            value = 42,
+            %variant = "Success",
+        });
+
+        assert_eq!(
+            value_to_document_with_variant_repr(&json, &VariantRepr::External).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_json_to_eure_with_variant_repr_internal() {
+        let json = json!({"type": "Success", "value": 42});
+        let expected = eure!({
+            value = 42,
+            %variant = "Success",
+        });
+
+        assert_eq!(
+            value_to_document_with_variant_repr(
+                &json,
+                &VariantRepr::Internal {
+                    tag: "type".to_string()
+                }
+            )
+            .unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_json_to_eure_with_variant_repr_adjacent() {
+        let json = json!({"kind": "Success", "payload": {"value": 42}});
+        let expected = eure!({
+            value = 42,
+            %variant = "Success",
+        });
+
+        assert_eq!(
+            value_to_document_with_variant_repr(
+                &json,
+                &VariantRepr::Adjacent {
+                    tag: "kind".to_string(),
+                    content: "payload".to_string()
+                }
+            )
+            .unwrap(),
             expected
         );
     }


### PR DESCRIPTION
### Motivation

- Allow JSON→Eure conversion to decode union variant representations using either an explicit CLI option or an optional schema file's `$interop.variant-repr` setting.
- Provide a JSON-to-Eure conversion path that does not require executing the query engine for simple conversions and supports decoding `external`, `internal`, and `adjacent` variant encodings.

### Description

- CLI: `from_json` accepts a new `--schema` argument and makes `--variant` optional, inferring the variant representation from the provided schema or defaulting to `Untagged` when omitted, and it now parses JSON with `serde_json::from_str` then converts via `value_to_document_with_variant_repr` instead of running the previous query.
- CLI: added helper functions `variant_format_to_repr`, `load_schema_variant_repr`, and `root_union_variant_repr` to map CLI inputs and load a schema's root union `VariantRepr` via `DocumentToSchemaQuery`.
- Library: added `value_to_document_with_variant_repr` and `convert_json_to_node_with_variant_repr` to `eure-json` to detect and decode variant encodings (`External`, `Internal`, `Adjacent`) and attach the `%variant` extension node using the `VARIANT` key.
- Tests: added unit tests `test_json_to_eure_with_variant_repr_external`, `test_json_to_eure_with_variant_repr_internal`, and `test_json_to_eure_with_variant_repr_adjacent` exercising the new variant-aware conversion behavior.

### Testing

- Ran unit tests in the modified crate with `cargo test -p eure-json` and the new variant tests (`test_json_to_eure_with_variant_repr_*`) all passed.
- Ran CLI crate tests with `cargo test -p eure-cli` and existing tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1f5c156388329842302746cd2fc23)