### PR TITLE
feat(cli): schema-aware to-json / from-json via serde-eure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1989,6 +1989,8 @@ dependencies = [
  "maud",
  "nu-ansi-term",
  "petgraph",
+ "serde",
+ "serde-eure",
  "serde_json",
  "toml",
  "url",

--- a/crates/eure-cli/Cargo.toml
+++ b/crates/eure-cli/Cargo.toml
@@ -31,6 +31,8 @@ toml = "0.9"
 eure-toml = { workspace = true }
 eure-tree = { workspace = true }
 eure-yaml = { workspace = true }
+serde = { workspace = true }
+serde-eure = { workspace = true }
 glob = "0.3"
 maud = "0.27.0"
 nu-ansi-term = "0.50"

--- a/crates/eure-cli/src/commands/from_json.rs
+++ b/crates/eure-cli/src/commands/from_json.rs
@@ -1,17 +1,26 @@
-use eure::query::{TextFile, TextFileContent, build_runtime};
+use eure::query::{
+    DocumentToSchemaQuery, TextFile, TextFileContent, WithFormattedError, build_runtime,
+};
 use eure::query_flow::DurabilityLevel;
 use eure_json::{Config as JsonConfig, JsonToEure};
 use eure_document::document::EureDocument;
 use eure_document::source::{EureSource, SourceDocument};
 use eure_schema::interop::VariantRepr;
 
-use crate::util::{VariantFormat, display_path, handle_query_error, read_input};
+use crate::args::CacheArgs;
+use crate::util::{
+    VariantFormat, display_path, handle_formatted_error, handle_query_error, read_input,
+    run_query_with_file_loading_cached,
+};
 
 #[derive(clap::Args)]
 pub struct Args {
     /// Path to JSON file to convert (use - for stdin)
     pub file: String,
-    /// Variant representation format
+    /// Schema file for schema-aware JSON via serde-eure (union wire shape follows schema $interop)
+    #[arg(short, long)]
+    pub schema: Option<String>,
+    /// Variant representation format (ignored when --schema is set)
     #[arg(short = 'v', long, value_enum, default_value = "external")]
     pub variant: VariantFormat,
     /// Tag field name for internal/adjacent representations
@@ -20,6 +29,9 @@ pub struct Args {
     /// Content field name for adjacent representation
     #[arg(short = 'c', long, default_value = "content")]
     pub content: String,
+    /// Cache options when the schema is loaded from a remote URL
+    #[command(flatten)]
+    pub cache: CacheArgs,
 }
 
 pub fn run(args: Args) {
@@ -40,30 +52,55 @@ pub fn run(args: Args) {
     // 2. Create query runtime
     let runtime = build_runtime();
 
-    // 3. Register JSON file as asset
     let file = TextFile::from_path(display_path(file_opt).into());
-    runtime.resolve_asset(
-        file.clone(),
-        TextFileContent(contents),
-        DurabilityLevel::Static,
-    );
+    let cache_opts = args.cache.to_cache_options();
 
-    // 4. Configure variant representation
-    let variant_repr = match args.variant {
-        VariantFormat::External => VariantRepr::External,
-        VariantFormat::Internal => VariantRepr::Internal { tag: args.tag },
-        VariantFormat::Adjacent => VariantRepr::Adjacent {
-            tag: args.tag,
-            content: args.content,
-        },
-        VariantFormat::Untagged => VariantRepr::Untagged,
-    };
-    let config = JsonConfig { variant_repr };
+    // 3–5. Convert JSON to EureDocument
+    let document = if let Some(schema_path) = args.schema.as_ref() {
+        let schema_file = match TextFile::parse(schema_path) {
+            Ok(f) => f,
+            Err(e) => {
+                eprintln!("Invalid schema path or URL: {e}");
+                std::process::exit(1);
+            }
+        };
 
-    // 5. Execute query to convert JSON to EureDocument
-    let document = match runtime.query(JsonToEure::new(file.clone(), config)) {
-        Ok(doc) => doc,
-        Err(e) => handle_query_error(e),
+        let validated = handle_formatted_error(run_query_with_file_loading_cached(
+            &runtime,
+            WithFormattedError::new(DocumentToSchemaQuery::new(schema_file), false),
+            Some(&cache_opts),
+        ));
+
+        let mut de = serde_json::Deserializer::from_str(&contents);
+        match serde_eure::from_deserializer(&mut de, &validated.schema) {
+            Ok(doc) => std::sync::Arc::new(doc),
+            Err(e) => {
+                eprintln!("Schema-aware JSON deserialization failed: {e}");
+                std::process::exit(1);
+            }
+        }
+    } else {
+        runtime.resolve_asset(
+            file.clone(),
+            TextFileContent(contents),
+            DurabilityLevel::Static,
+        );
+
+        let variant_repr = match args.variant {
+            VariantFormat::External => VariantRepr::External,
+            VariantFormat::Internal => VariantRepr::Internal { tag: args.tag },
+            VariantFormat::Adjacent => VariantRepr::Adjacent {
+                tag: args.tag,
+                content: args.content,
+            },
+            VariantFormat::Untagged => VariantRepr::Untagged,
+        };
+        let config = JsonConfig { variant_repr };
+
+        match runtime.query(JsonToEure::new(file.clone(), config)) {
+            Ok(doc) => doc,
+            Err(e) => handle_query_error(e),
+        }
     };
 
     // 6. Build minimal SourceDocument for formatting

--- a/crates/eure-cli/src/commands/to_json.rs
+++ b/crates/eure-cli/src/commands/to_json.rs
@@ -1,15 +1,29 @@
-use eure::query::{TextFile, TextFileContent, WithFormattedError, build_runtime};
+use eure::query::{
+    DocumentToSchemaQuery, ParseDocument, TextFile, TextFileContent, WithFormattedError,
+    build_runtime,
+};
 use eure::query_flow::DurabilityLevel;
+use eure_document::document::EureDocument;
 use eure_json::{Config as JsonConfig, EureToJsonFormatted};
 use eure_schema::interop::VariantRepr;
+use eure_schema::SchemaDocument;
+use serde::Serialize;
+use serde_json::Serializer as JsonSerializer;
 
-use crate::util::{VariantFormat, display_path, handle_formatted_error, read_input};
+use crate::args::CacheArgs;
+use crate::util::{
+    VariantFormat, display_path, handle_formatted_error, read_input,
+    run_query_with_file_loading_cached,
+};
 
 #[derive(clap::Args)]
 pub struct Args {
     /// Path to Eure file to convert (use - for stdin)
     pub file: String,
-    /// Variant representation format
+    /// Schema file for schema-aware JSON via serde-eure (union wire shape follows schema $interop)
+    #[arg(short, long)]
+    pub schema: Option<String>,
+    /// Variant representation format (ignored when --schema is set)
     #[arg(short = 'v', long, value_enum, default_value = "external")]
     pub variant: VariantFormat,
     /// Tag field name for internal/adjacent representations
@@ -21,6 +35,21 @@ pub struct Args {
     /// Pretty print JSON output
     #[arg(short, long)]
     pub pretty: bool,
+    /// Cache options when the schema is loaded from a remote URL
+    #[command(flatten)]
+    pub cache: CacheArgs,
+}
+
+/// Bridges `serde_json::Serializer` with serde-eure's schema-aware `Serialize` implementation.
+struct SchemaAwareEureDocument<'a> {
+    doc: &'a EureDocument,
+    schema: &'a SchemaDocument,
+}
+
+impl Serialize for SchemaAwareEureDocument<'_> {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        serde_eure::to_serializer(ser, self.doc, self.schema)
+    }
 }
 
 pub fn run(args: Args) {
@@ -48,24 +77,65 @@ pub fn run(args: Args) {
         DurabilityLevel::Static,
     );
 
-    // Configure variant representation
-    let variant_repr = match args.variant {
-        VariantFormat::External => VariantRepr::External,
-        VariantFormat::Internal => VariantRepr::Internal { tag: args.tag },
-        VariantFormat::Adjacent => VariantRepr::Adjacent {
-            tag: args.tag,
-            content: args.content,
-        },
-        VariantFormat::Untagged => VariantRepr::Untagged,
+    let cache_opts = args.cache.to_cache_options();
+
+    let json_value = if let Some(schema_path) = args.schema.as_ref() {
+        let schema_file = match TextFile::parse(schema_path) {
+            Ok(f) => f,
+            Err(e) => {
+                eprintln!("Invalid schema path or URL: {e}");
+                std::process::exit(1);
+            }
+        };
+
+        let validated = handle_formatted_error(run_query_with_file_loading_cached(
+            &runtime,
+            WithFormattedError::new(DocumentToSchemaQuery::new(schema_file), false),
+            Some(&cache_opts),
+        ));
+
+        let parsed = handle_formatted_error(run_query_with_file_loading_cached(
+            &runtime,
+            WithFormattedError::new(ParseDocument::new(file.clone()), true),
+            Some(&cache_opts),
+        ));
+
+        let wrapped = SchemaAwareEureDocument {
+            doc: &parsed.doc,
+            schema: &validated.schema,
+        };
+        let mut buf = Vec::new();
+        let mut ser = JsonSerializer::new(&mut buf);
+        if let Err(e) = wrapped.serialize(&mut ser) {
+            eprintln!("Schema-aware JSON serialization failed: {e}");
+            std::process::exit(1);
+        }
+        match serde_json::from_slice(&buf) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("Internal error building JSON value: {e}");
+                std::process::exit(1);
+            }
+        }
+    } else {
+        // Configure variant representation (schema-free path)
+        let variant_repr = match args.variant {
+            VariantFormat::External => VariantRepr::External,
+            VariantFormat::Internal => VariantRepr::Internal { tag: args.tag },
+            VariantFormat::Adjacent => VariantRepr::Adjacent {
+                tag: args.tag,
+                content: args.content,
+            },
+            VariantFormat::Untagged => VariantRepr::Untagged,
+        };
+
+        let config = JsonConfig { variant_repr };
+
+        handle_formatted_error(runtime.query(WithFormattedError::new(
+            EureToJsonFormatted::new(file.clone(), config),
+            true,
+        )))
     };
-
-    let config = JsonConfig { variant_repr };
-
-    // Convert document to JSON
-    let json_value = handle_formatted_error(runtime.query(WithFormattedError::new(
-        EureToJsonFormatted::new(file.clone(), config),
-        true,
-    )));
 
     // Output JSON
     let output = if args.pretty {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds optional `--schema` to `eure to-json` and `eure from-json`. When set, conversion uses [serde-eure](https://github.com/Hihaheho/eure/tree/main/crates/serde-eure) with a `SchemaDocument` loaded through `DocumentToSchemaQuery` (same path as the test suite’s JSON↔Eure scenarios). Remote schema URLs use the same cache flags as `eure check` (`--offline`, `--refresh`, `--max-age`, `--cache-dir`).

When `--schema` is omitted, behavior is unchanged: `eure-json` and CLI `-v`/`-t`/`-c` still control variant wire format from `$variant`.

## Notes

- Union JSON shape under `--schema` follows each union’s `$interop.variant-repr` in the schema (default external), not the CLI `-v` flag.
- `make check` completed clippy and tests locally; the final `eure-check` step failed here only because `https://eure.dev/.../eure-schema.schema.eure` was unreachable from this environment (network), not due to this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-efc3053e-d9b1-411d-b3c4-001406217aef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efc3053e-d9b1-411d-b3c4-001406217aef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

